### PR TITLE
Gh 192 mvn tests bugfix

### DIFF
--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/MaxTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/MaxTest.java
@@ -16,7 +16,6 @@
 
 package uk.gov.gchq.koryphe.impl.binaryoperator;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.koryphe.binaryoperator.BinaryOperatorTest;
@@ -31,20 +30,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MaxTest extends BinaryOperatorTest {
 
-    private Comparable state;
-
-    @BeforeEach
-    public void before() {
-        state = null;
-    }
-
     @Test
     public void testAggregateInIntMode() {
         // Given
         final Max max = new Max();
 
         // When 1
-        state = max.apply(1, null);
+        Comparable state = max.apply(1, null);
 
         // Then 1
         assertTrue(state instanceof Integer);
@@ -71,7 +63,7 @@ public class MaxTest extends BinaryOperatorTest {
         final Max max = new Max();
 
         // When 1
-        state = max.apply(2L, state);
+        Comparable state = max.apply(2L, null);
 
         // Then 1
         assertTrue(state instanceof Long);
@@ -98,7 +90,7 @@ public class MaxTest extends BinaryOperatorTest {
         final Max max = new Max();
 
         // When 1
-        state = max.apply(1.1d, state);
+        Comparable state = max.apply(1.1d, null);
 
         // Then 1
         assertTrue(state instanceof Double);
@@ -125,17 +117,17 @@ public class MaxTest extends BinaryOperatorTest {
         final Max max = new Max();
 
         // When 1
-        state = max.apply(state, 1);
+        final Comparable newState = max.apply(null, 1);
 
         // When 2
-        assertThrows(ClassCastException.class, () -> max.apply(state, 3L));
+        assertThrows(ClassCastException.class, () -> max.apply(newState, 3L));
 
         // When 3
-        assertThrows(ClassCastException.class, () -> max.apply(state, 2.1d));
+        assertThrows(ClassCastException.class, () -> max.apply(newState, 2.1d));
 
         // Then 3
-        assertTrue(state instanceof Integer);
-        assertEquals(1, state);
+        assertTrue(newState instanceof Integer);
+        assertEquals(1, newState);
     }
 
     @Test

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/MinTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/MinTest.java
@@ -16,7 +16,6 @@
 
 package uk.gov.gchq.koryphe.impl.binaryoperator;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.koryphe.binaryoperator.BinaryOperatorTest;
@@ -31,20 +30,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MinTest extends BinaryOperatorTest {
 
-    private Comparable state;
-
-    @BeforeEach
-    public void before() {
-        state = null;
-    }
-
     @Test
     public void testAggregateInIntMode() {
         // Given
         final Min min = new Min();
 
         // When 1
-        state = min.apply(1, state);
+        Comparable state = min.apply(1, null);
 
         // Then 1
         assertTrue(state instanceof Integer);
@@ -71,7 +63,7 @@ public class MinTest extends BinaryOperatorTest {
         final Min min = new Min();
 
         // When 1
-        state = min.apply(1L, state);
+        Comparable state = min.apply(1L, null);
 
         // Then 1
         assertTrue(state instanceof Long);
@@ -97,9 +89,8 @@ public class MinTest extends BinaryOperatorTest {
         // Given
         final Min min = new Min();
 
-
         // When 1
-        state = min.apply(2.1d, state);
+        Comparable state = min.apply(2.1d, null);
 
         // Then 1
         assertTrue(state instanceof Double);
@@ -126,13 +117,13 @@ public class MinTest extends BinaryOperatorTest {
         final Min min = new Min();
 
         // When 1
-        state = min.apply(5, state);
+        Comparable state = min.apply(5, null);
 
         // When 2
-        assertThrows(ClassCastException.class, () -> state = min.apply(2L, state));
+        assertThrows(ClassCastException.class, () -> min.apply(2L, state));
 
         // When 3
-        assertThrows(ClassCastException.class, () -> state = min.apply(2.1d, state));
+        assertThrows(ClassCastException.class, () -> min.apply(2.1d, state));
 
         // Then 3
         assertTrue(state instanceof Integer);

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/ProductTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/ProductTest.java
@@ -16,7 +16,6 @@
 
 package uk.gov.gchq.koryphe.impl.binaryoperator;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.koryphe.binaryoperator.BinaryOperatorTest;
@@ -31,20 +30,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProductTest extends BinaryOperatorTest {
 
-    private Number state;
-
-    @BeforeEach
-    public void before() {
-        state = null;
-    }
-
     @Test
     public void testAggregateInShortMode() {
         // Given
         final Product product = new Product();
 
         // When 1
-        state = product.apply((short) 2, state);
+        Number state = product.apply((short) 2, null);
 
         // Then 1
         assertTrue(state instanceof Short);
@@ -72,14 +64,13 @@ public class ProductTest extends BinaryOperatorTest {
         assertEquals(Short.MAX_VALUE, state);
     }
 
-
     @Test
     public void testAggregateInIntMode() {
         // Given
         final Product product = new Product();
 
         // When 1
-        state = product.apply(2, state);
+        Number state = product.apply(2, null);
 
         // Then 1
         assertTrue(state instanceof Integer);
@@ -106,21 +97,21 @@ public class ProductTest extends BinaryOperatorTest {
         final Product product = new Product();
 
         // When 1
-        state = product.apply(2, state);
+        final Number state = product.apply(2, null);
 
         // Then 1
         assertTrue(state instanceof Integer);
         assertEquals(2, state);
 
         // When 2
-        assertThrows(ClassCastException.class, () -> state = product.apply(2.7d, state));
+        assertThrows(ClassCastException.class, () -> product.apply(2.7d, state));
 
         // Then 2
         assertTrue(state instanceof Integer);
         assertEquals(2, state);
 
         // When 3
-        assertThrows(ClassCastException.class, () -> state = product.apply(1L, state));
+        assertThrows(ClassCastException.class, () -> product.apply(1L, state));
 
         // Then 3
         assertTrue(state instanceof Integer);
@@ -133,7 +124,7 @@ public class ProductTest extends BinaryOperatorTest {
         final Product product = new Product();
 
         // When 1
-        state = product.apply(2L, state);
+        Number state = product.apply(2L, null);
 
         // Then 1
         assertTrue(state instanceof Long);
@@ -158,27 +149,27 @@ public class ProductTest extends BinaryOperatorTest {
     public void testAggregateInLongModeMixedInput() {
         // Given
         final Product product = new Product();
-        state = 1L;
+        final Number state1 = 1L;
 
         // When 1
-        assertThrows(ClassCastException.class, () -> state = product.apply(1, state));
+        assertThrows(ClassCastException.class, () -> product.apply(1, state1));
 
         // Then 1
-        assertEquals(1L, state);
+        assertEquals(1L, state1);
 
         // When 2
-        state = product.apply(3L, state);
+        final Number state2 = product.apply(3L, 1L);
 
         // Then 2
-        assertTrue(state instanceof Long);
-        assertEquals(3L, state);
+        assertTrue(state2 instanceof Long);
+        assertEquals(3L, state2);
 
         // When 3
-        assertThrows(ClassCastException.class, () -> state = product.apply(2.5d, state));
+        assertThrows(ClassCastException.class, () -> product.apply(2.5d, state2));
 
         // Then 3
-        assertTrue(state instanceof Long);
-        assertEquals(3L, state);
+        assertTrue(state2 instanceof Long);
+        assertEquals(3L, state2);
     }
 
     @Test
@@ -187,7 +178,7 @@ public class ProductTest extends BinaryOperatorTest {
         final Product product = new Product();
 
         // When 1
-        state = product.apply(1.2d, state);
+        Number state = product.apply(1.2d, null);
 
         // Then 1
         assertTrue(state instanceof Double);
@@ -214,7 +205,7 @@ public class ProductTest extends BinaryOperatorTest {
         final Product product = new Product();
 
         // When 1
-        state = product.apply(1.2f, state);
+        Number state = product.apply(1.2f, null);
 
         // Then 1
         assertTrue(state instanceof Float);
@@ -239,50 +230,49 @@ public class ProductTest extends BinaryOperatorTest {
     public void testAggregateInDoubleModeMixedInput() {
         // Given
         final Product product = new Product();
-        state = 1d;
+        final Number state = 1d;
 
         // When 1
-        assertThrows(ClassCastException.class, () -> state = product.apply(1, state));
+        assertThrows(ClassCastException.class, () -> product.apply(1, state));
 
         // Then 1
         assertEquals(1d, state);
 
         // When 2
-        assertThrows(ClassCastException.class, () -> state = product.apply(3L, state));
+        assertThrows(ClassCastException.class, () -> product.apply(3L, state));
 
         // Then 2
         assertEquals(1d, state);
 
         // When 3
-        state = product.apply(2.1d, state);
+        final Number state2 = product.apply(2.1d, state);
 
         // Then 3
-        assertTrue(state instanceof Double);
-        assertEquals(2.1d, state);
+        assertTrue(state2 instanceof Double);
+        assertEquals(2.1d, state2);
     }
 
     @Test
     public void testAggregateInAutoModeIntInputFirst() {
         // Given
         final Product product = new Product();
-        state = 1;
 
         // When 1
-        state = product.apply(2, state);
+        Number state = product.apply(2, 1);
 
         // Then 1
         assertTrue(state instanceof Integer);
         assertEquals(2, state);
 
         // When 2
-        assertThrows(ClassCastException.class, () -> state = product.apply(3L, state));
+        assertThrows(ClassCastException.class, () -> product.apply(3L, state));
 
         // Then 2
         assertTrue(state instanceof Integer);
         assertEquals(2, state);
 
         // When 3
-        assertThrows(ClassCastException.class, () -> state = product.apply(2.1d, state));
+        assertThrows(ClassCastException.class, () -> product.apply(2.1d, state));
 
         // Then 3
         assertTrue(state instanceof Integer);
@@ -293,24 +283,23 @@ public class ProductTest extends BinaryOperatorTest {
     public void testAggregateInAutoModeLongInputFirst() {
         // Given
         final Product product = new Product();
-        state = 1L;
 
         // When 1
-        state = product.apply(2L, state);
+        Number state = product.apply(2L, 1L);
 
         // Then 1
         assertTrue(state instanceof Long);
         assertEquals(2L, state);
 
         // When 2
-        assertThrows(ClassCastException.class, () -> state = product.apply(3, state));
+        assertThrows(ClassCastException.class, () -> product.apply(3, state));
 
         // Then 2
         assertTrue(state instanceof Long);
         assertEquals(2L, state);
 
         // When 3
-        assertThrows(ClassCastException.class, () -> state = product.apply(2.1d, state));
+        assertThrows(ClassCastException.class, () -> product.apply(2.1d, state));
 
         // Then 3
         assertTrue(state instanceof Long);
@@ -321,24 +310,23 @@ public class ProductTest extends BinaryOperatorTest {
     public void testAggregateInAutoModeDoubleInputFirst() {
         // Given
         final Product product = new Product();
-        state = 1d;
 
         // When 1
-        state = product.apply(1.1d, state);
+        final Number state = product.apply(1.1d, 1d);
 
         // Then 1
         assertTrue(state instanceof Double);
         assertEquals(1.1d, state);
 
         // When 2
-        assertThrows(ClassCastException.class, () -> state = product.apply(2, state));
+        assertThrows(ClassCastException.class, () -> product.apply(2, state));
 
         // Then 2
         assertTrue(state instanceof Double);
         assertEquals(1.1d, state);
 
         // When 3
-        assertThrows(ClassCastException.class, () -> state = product.apply(1L, state));
+        assertThrows(ClassCastException.class, () -> product.apply(1L, state));
 
         // Then 3
         assertTrue(state instanceof Double);

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/SumTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/SumTest.java
@@ -16,7 +16,6 @@
 
 package uk.gov.gchq.koryphe.impl.binaryoperator;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.koryphe.binaryoperator.BinaryOperatorTest;
@@ -32,20 +31,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SumTest extends BinaryOperatorTest {
 
-    private Number state;
-
-    @BeforeEach
-    public void before() {
-        state = null;
-    }
-
     @Test
     public void testAggregateShorts() {
         // Given
         final Sum sum = new Sum();
 
         // When 1
-        state = sum.apply((short) 1, state);
+        Number state = sum.apply((short) 1, null);
 
         // Then 1
         assertTrue(state instanceof Short);
@@ -79,7 +71,7 @@ public class SumTest extends BinaryOperatorTest {
         final Sum sum = new Sum();
 
         // When 1
-        state = sum.apply(1, state);
+        Number state = sum.apply(1, null);
 
         // Then 1
         assertTrue(state instanceof Integer);
@@ -106,21 +98,21 @@ public class SumTest extends BinaryOperatorTest {
         final Sum sum = new Sum();
 
         // When 1
-        state = sum.apply(1, state);
+        Number state = sum.apply(1, null);
 
         // Then 1
         assertTrue(state instanceof Integer);
         assertEquals(1, state);
 
         // When 2
-        assertThrows(ClassCastException.class, () -> state = sum.apply(2.7d, state));
+        assertThrows(ClassCastException.class, () -> sum.apply(2.7d, state));
 
         // Then 2
         assertTrue(state instanceof Integer);
         assertEquals(1, state);
 
         // When 3
-        assertThrows(ClassCastException.class, () -> state = sum.apply(1L, state));
+        assertThrows(ClassCastException.class, () -> sum.apply(1L, state));
 
         // Then 3
         assertTrue(state instanceof Integer);
@@ -133,7 +125,7 @@ public class SumTest extends BinaryOperatorTest {
         final Sum sum = new Sum();
 
         // When 1
-        state = sum.apply(2L, state);
+        Number state = sum.apply(2L, null);
 
         // Then 1
         assertTrue(state instanceof Long);
@@ -158,27 +150,27 @@ public class SumTest extends BinaryOperatorTest {
     public void testAggregateInLongModeMixedInput() {
         // Given
         final Sum sum = new Sum();
-        state = 0L;
+        final Number state = 0L;
 
         // When 1
-        assertThrows(ClassCastException.class, () -> state = sum.apply(1, state));
+        assertThrows(ClassCastException.class, () -> sum.apply(1, state));
 
         // Then 1
         assertEquals(0L, state);
 
         // When 2
-        state = sum.apply(3L, state);
+        final Number state2 = sum.apply(3L, state);
 
         // Then 2
-        assertTrue(state instanceof Long);
-        assertEquals(3L, state);
+        assertTrue(state2 instanceof Long);
+        assertEquals(3L, state2);
 
         // When 3
-        assertThrows(ClassCastException.class, () -> state = sum.apply(2.5d, state));
+        assertThrows(ClassCastException.class, () -> sum.apply(2.5d, state2));
 
         // Then 3
-        assertTrue(state instanceof Long);
-        assertEquals(3L, state);
+        assertTrue(state2 instanceof Long);
+        assertEquals(3L, state2);
     }
 
     @Test
@@ -187,7 +179,7 @@ public class SumTest extends BinaryOperatorTest {
         final Sum sum = new Sum();
 
         // When 1
-        state = sum.apply(1.1f, state);
+        Number state = sum.apply(1.1f, null);
 
         // Then 1
         assertTrue(state instanceof Float);
@@ -214,7 +206,7 @@ public class SumTest extends BinaryOperatorTest {
         final Sum sum = new Sum();
 
         // When 1
-        state = sum.apply(1.1d, state);
+        Number state = sum.apply(1.1d, null);
 
         // Then 1
         assertTrue(state instanceof Double);
@@ -239,50 +231,49 @@ public class SumTest extends BinaryOperatorTest {
     public void testAggregateInDoubleModeMixedInput() {
         // Given
         final Sum sum = new Sum();
-        state = 0d;
+        final Number state = 0d;
 
         // When 1
-        assertThrows(ClassCastException.class, () -> state = sum.apply(1, state));
+        assertThrows(ClassCastException.class, () -> sum.apply(1, state));
 
         // Then 1
         assertEquals(0d, state);
 
         // When 2
-        assertThrows(ClassCastException.class, () -> state = sum.apply(3L, state));
+        assertThrows(ClassCastException.class, () -> sum.apply(3L, state));
 
         // Then 2
         assertEquals(0d, state);
 
         // When 3
-        state = sum.apply(2.1d, state);
+        final Number state2 = sum.apply(2.1d, state);
 
         // Then 3
-        assertTrue(state instanceof Double);
-        assertEquals(2.1d, state);
+        assertTrue(state2 instanceof Double);
+        assertEquals(2.1d, state2);
     }
 
     @Test
     public void testAggregateInAutoModeIntInputFirst() {
         // Given
         final Sum sum = new Sum();
-        state = 0;
 
         // When 1
-        state = sum.apply(1, state);
+        final Number state = sum.apply(1, 0);
 
         // Then 1
         assertTrue(state instanceof Integer);
         assertEquals(1, state);
 
         // When 2
-        assertThrows(ClassCastException.class, () -> state = sum.apply(3L, state));
+        assertThrows(ClassCastException.class, () -> sum.apply(3L, state));
 
         // Then 2
         assertTrue(state instanceof Integer);
         assertEquals(1, state);
 
         // When 3
-        assertThrows(ClassCastException.class, () -> state = sum.apply(2.1d, state));
+        assertThrows(ClassCastException.class, () -> sum.apply(2.1d, state));
 
         // Then 3
         assertTrue(state instanceof Integer);
@@ -293,24 +284,23 @@ public class SumTest extends BinaryOperatorTest {
     public void testAggregateInAutoModeLongInputFirst() {
         // Given
         final Sum sum = new Sum();
-        state = 0L;
 
         // When 1
-        state = sum.apply(1L, state);
+        final Number state = sum.apply(1L, 0L);
 
         // Then 1
         assertTrue(state instanceof Long);
         assertEquals(1L, state);
 
         // When 2
-        assertThrows(ClassCastException.class, () -> state = sum.apply(3, state));
+        assertThrows(ClassCastException.class, () -> sum.apply(3, state));
 
         // Then 2
         assertTrue(state instanceof Long);
         assertEquals(1L, state);
 
         // When 3
-        assertThrows(ClassCastException.class, () -> state = sum.apply(2.1d, state));
+        assertThrows(ClassCastException.class, () -> sum.apply(2.1d, state));
 
         // Then 3
         assertTrue(state instanceof Long);
@@ -321,24 +311,23 @@ public class SumTest extends BinaryOperatorTest {
     public void testAggregateInAutoModeDoubleInputFirst() {
         // Given
         final Sum sum = new Sum();
-        state = 0d;
 
         // When 1
-        state = sum.apply(1.1d, state);
+        final Number state = sum.apply(1.1d, 0d);
 
         // Then 1
         assertTrue(state instanceof Double);
         assertEquals(1.1d, state);
 
         // When 2
-        assertThrows(ClassCastException.class, () -> state = sum.apply(2, state));
+        assertThrows(ClassCastException.class, () -> sum.apply(2, state));
 
         // Then 2
         assertTrue(state instanceof Double);
         assertEquals(1.1d, state);
 
         // When 3
-        assertThrows(ClassCastException.class, () -> state = sum.apply(1L, state));
+        assertThrows(ClassCastException.class, () -> sum.apply(1L, state));
 
         // Then 3
         assertTrue(state instanceof Double);
@@ -351,7 +340,7 @@ public class SumTest extends BinaryOperatorTest {
         final Sum sum = new Sum();
 
         // When
-        state = sum.apply(null, state);
+        final Number state = sum.apply(null, null);
 
         // Then
         assertNull(state);
@@ -364,7 +353,7 @@ public class SumTest extends BinaryOperatorTest {
 
         // When 1
         int firstValue = 1;
-        state = sum.apply(firstValue, state);
+        Number state = sum.apply(firstValue, null);
 
         // Then
         assertTrue(state instanceof Integer);
@@ -384,7 +373,7 @@ public class SumTest extends BinaryOperatorTest {
 
         // When 1
         long firstValue = 1L;
-        state = sum.apply(firstValue, state);
+        Number state = sum.apply(firstValue, null);
 
         // Then
         assertTrue(state instanceof Long);
@@ -392,6 +381,7 @@ public class SumTest extends BinaryOperatorTest {
 
         // When 2
         state = sum.apply(null, state);
+
         // Then
         assertTrue(state instanceof Long);
         assertEquals(firstValue, state);
@@ -404,7 +394,7 @@ public class SumTest extends BinaryOperatorTest {
 
         // When 1
         double firstValue = 1.0f;
-        state = sum.apply(firstValue, state);
+        Number state = sum.apply(firstValue, null);
 
         // Then
         assertTrue(state instanceof Double);

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jackson.version>2.6.5</jackson.version>
         <junit5.version>5.6.0</junit5.version>
+        <junitSurefireProvider.version>1.1.0</junitSurefireProvider.version>
         <mockito.version>1.9.5</mockito.version>
         <slf4j.api.version>1.7.25</slf4j.api.version>
 
@@ -33,7 +34,7 @@
         <commons-codec.version>1.6</commons-codec.version>
         <commons-io.version>2.4</commons-io.version>
         <org.json-version>20180813</org.json-version>
-        <compiler.plugin.verson>2.3.2</compiler.plugin.verson>
+        <compiler.plugin.verson>3.8.0</compiler.plugin.verson>
         <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
         <jacoco.plugin.version>0.7.7.201606060606</jacoco.plugin.version>
@@ -162,6 +163,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+            <version>${junitSurefireProvider.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>${hamcrest.version}</version>
@@ -276,6 +289,11 @@
                     <meminitial>128m</meminitial>
                     <maxmem>1024m</maxmem>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -163,12 +163,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit5.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-surefire-provider</artifactId>
             <version>${junitSurefireProvider.version}</version>


### PR DESCRIPTION
Changes that ensures tests are picked up for `mvn clean install` commands.

I've explicitly added the surefire-plugin 2.22.1 to <build /> in pom.xml.

I've also cleared up the ClassCastException errors that were throwing unexpectedly by refactoring the tests.

Let me know what you think? - Or if there are any more mvn commands other than the above that need to be checked to ensure it is fixed, cheers


*Also I should note that the `-q` quiet option hides all the tests being ran on the pipeline - however if you ran it locally `verify -P travis,test -B` you can see they are 