### PR TITLE
Changes for Upgrade to Java 11 #194

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
   directories:
   - $HOME/.m2
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 sudo: false
 dist: trusty
 addons:

--- a/code-style/checkstyle.xml
+++ b/code-style/checkstyle.xml
@@ -38,14 +38,10 @@
     </module>
 
     <module name="TreeWalker">
-        <property name="cacheFile" value="${checkstyle.cache.file}"/>
-
         <module name="SuppressWarningsHolder"/>
 
         <module name="AtclauseOrder"/>
-        <module name="JavadocMethod">
-            <property name="allowMissingJavadoc" value="true"/>
-        </module>
+        <module name="JavadocMethod"/>
         <module name="JavadocStyle">
             <property name="checkFirstSentence" value="false"/>
         </module>

--- a/core/src/main/java/uk/gov/gchq/koryphe/binaryoperator/KorypheBinaryOperator.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/binaryoperator/KorypheBinaryOperator.java
@@ -47,7 +47,7 @@ public abstract class KorypheBinaryOperator<T> implements BinaryOperator<T> {
         return _apply(state, input);
     }
 
-    protected abstract T _apply(final T a, final T b);
+    protected abstract T _apply(T a, T b);
 
     @Override
     public boolean equals(final Object obj) {

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/binaryoperator/NumericAggregateFunction.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/binaryoperator/NumericAggregateFunction.java
@@ -48,13 +48,13 @@ public abstract class NumericAggregateFunction extends KorypheBinaryOperator<Num
         return null;
     }
 
-    protected abstract Integer aggregateInt(final Integer a, final Integer b);
+    protected abstract Integer aggregateInt(Integer a, Integer b);
 
-    protected abstract Long aggregateLong(final Long a, final Long b);
+    protected abstract Long aggregateLong(Long a, Long b);
 
-    protected abstract Double aggregateDouble(final Double a, final Double b);
+    protected abstract Double aggregateDouble(Double a, Double b);
 
-    protected abstract Float aggregateFloat(final Float a, final Float b);
+    protected abstract Float aggregateFloat(Float a, Float b);
 
-    protected abstract Short aggregateShort(final Short a, final Short b);
+    protected abstract Short aggregateShort(Short a, Short b);
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/Gunzip.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/Gunzip.java
@@ -47,7 +47,7 @@ public class Gunzip extends KorypheFunction<byte[], byte[]> {
             return new byte[0];
         }
 
-        try (final GZIPInputStream gzipStream = new GZIPInputStream(new ByteArrayInputStream(compressed))) {
+        try (GZIPInputStream gzipStream = new GZIPInputStream(new ByteArrayInputStream(compressed))) {
             return IOUtils.toByteArray(gzipStream);
         } catch (final IOException e) {
             throw new RuntimeException("Failed to decompress provided gzipped string", e);

--- a/core/src/main/java/uk/gov/gchq/koryphe/signature/InputValidator.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/signature/InputValidator.java
@@ -19,5 +19,5 @@ package uk.gov.gchq.koryphe.signature;
 import uk.gov.gchq.koryphe.ValidationResult;
 
 public interface InputValidator {
-    ValidationResult isInputValid(final Class<?>... arguments);
+    ValidationResult isInputValid(Class<?>... arguments);
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/signature/OutputValidator.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/signature/OutputValidator.java
@@ -19,5 +19,5 @@ package uk.gov.gchq.koryphe.signature;
 import uk.gov.gchq.koryphe.ValidationResult;
 
 public interface OutputValidator {
-    ValidationResult isOutputValid(final Class<?>... arguments);
+    ValidationResult isOutputValid(Class<?>... arguments);
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/signature/Signature.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/signature/Signature.java
@@ -56,7 +56,7 @@ public abstract class Signature {
      * @param arguments Class or Tuple of classes to test.
      * @return ValidationResult containing the isValid flag and errors messages.
      */
-    public abstract ValidationResult assignable(final Class<?>... arguments);
+    public abstract ValidationResult assignable(Class<?>... arguments);
 
     public abstract Class[] getClasses();
 

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/function/KorypheFunction2.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/function/KorypheFunction2.java
@@ -19,7 +19,7 @@ package uk.gov.gchq.koryphe.tuple.function;
 import uk.gov.gchq.koryphe.tuple.n.Tuple2;
 
 public abstract class KorypheFunction2<T, U, R> extends KorypheFunctionN<Tuple2<T, U>, R> {
-    public abstract R apply(final T t, final U u);
+    public abstract R apply(T t, U u);
 
     public R delegateApply(final Tuple2<T, U> tuple) {
         return apply(tuple.get0(), tuple.get1());

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/function/KorypheFunction3.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/function/KorypheFunction3.java
@@ -19,7 +19,7 @@ package uk.gov.gchq.koryphe.tuple.function;
 import uk.gov.gchq.koryphe.tuple.n.Tuple3;
 
 public abstract class KorypheFunction3<T, U, V, R> extends KorypheFunctionN<Tuple3<T, U, V>, R> {
-    public abstract R apply(final T t, final U u, final V v);
+    public abstract R apply(T t, U u, V v);
 
     @Override
     public R delegateApply(final Tuple3<T, U, V> tuple) {

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/function/KorypheFunction4.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/function/KorypheFunction4.java
@@ -19,7 +19,7 @@ package uk.gov.gchq.koryphe.tuple.function;
 import uk.gov.gchq.koryphe.tuple.n.Tuple4;
 
 public abstract class KorypheFunction4<T, U, V, W, R> extends KorypheFunctionN<Tuple4<T, U, V, W>, R> {
-    public abstract R apply(final T t, final U u, final V v, final W w);
+    public abstract R apply(T t, U u, V v, W w);
 
     @Override
     public R delegateApply(final Tuple4<T, U, V, W> tuple) {

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/function/KorypheFunction5.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/function/KorypheFunction5.java
@@ -19,7 +19,7 @@ package uk.gov.gchq.koryphe.tuple.function;
 import uk.gov.gchq.koryphe.tuple.n.Tuple5;
 
 public abstract class KorypheFunction5<T, U, V, W, X, R> extends KorypheFunctionN<Tuple5<T, U, V, W, X>, R> {
-    public abstract R apply(final T t, final U u, final V v, final W w, final X x);
+    public abstract R apply(T t, U u, V v, W w, X x);
 
     @Override
     public R delegateApply(final Tuple5<T, U, V, W, X> tuple) {

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/function/KorypheFunctionN.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/function/KorypheFunctionN.java
@@ -33,5 +33,5 @@ public abstract class KorypheFunctionN<TUPLE extends Tuple<Integer>, R> extends 
         }
     }
 
-    protected abstract R delegateApply(final TUPLE tuple);
+    protected abstract R delegateApply(TUPLE tuple);
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/predicate/KoryphePredicate2.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/predicate/KoryphePredicate2.java
@@ -19,7 +19,7 @@ package uk.gov.gchq.koryphe.tuple.predicate;
 import uk.gov.gchq.koryphe.tuple.n.Tuple2;
 
 public abstract class KoryphePredicate2<T, U> extends KoryphePredicateN<Tuple2<T, U>> {
-    public abstract boolean test(final T t, final U u);
+    public abstract boolean test(T t, U u);
 
     @Override
     protected boolean delegateTest(final Tuple2<T, U> tuple) {

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/predicate/KoryphePredicate3.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/predicate/KoryphePredicate3.java
@@ -19,7 +19,7 @@ package uk.gov.gchq.koryphe.tuple.predicate;
 import uk.gov.gchq.koryphe.tuple.n.Tuple3;
 
 public abstract class KoryphePredicate3<T, U, V> extends KoryphePredicateN<Tuple3<T, U, V>> {
-    public abstract boolean test(final T t, final U u, final V v);
+    public abstract boolean test(T t, U u, V v);
 
     @Override
     protected boolean delegateTest(final Tuple3<T, U, V> tuple) {

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/predicate/KoryphePredicate4.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/predicate/KoryphePredicate4.java
@@ -19,7 +19,7 @@ package uk.gov.gchq.koryphe.tuple.predicate;
 import uk.gov.gchq.koryphe.tuple.n.Tuple4;
 
 public abstract class KoryphePredicate4<T, U, V, W> extends KoryphePredicateN<Tuple4<T, U, V, W>> {
-    public abstract boolean test(final T t, final U u, final V v, final W w);
+    public abstract boolean test(T t, U u, V v, W w);
 
     @Override
     protected boolean delegateTest(final Tuple4<T, U, V, W> tuple) {

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/predicate/KoryphePredicate5.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/predicate/KoryphePredicate5.java
@@ -19,7 +19,7 @@ package uk.gov.gchq.koryphe.tuple.predicate;
 import uk.gov.gchq.koryphe.tuple.n.Tuple5;
 
 public abstract class KoryphePredicate5<T, U, V, W, X> extends KoryphePredicateN<Tuple5<T, U, V, W, X>> {
-    public abstract boolean test(final T t, final U u, final V v, final W w, final X x);
+    public abstract boolean test(T t, U u, V v, W w, X x);
 
     @Override
     protected boolean delegateTest(final Tuple5<T, U, V, W, X> tuple) {

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/predicate/KoryphePredicateN.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/predicate/KoryphePredicateN.java
@@ -33,5 +33,5 @@ public abstract class KoryphePredicateN<TUPLE extends Tuple<Integer>> extends Ko
         }
     }
 
-    protected abstract boolean delegateTest(final TUPLE tuple);
+    protected abstract boolean delegateTest(TUPLE tuple);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <mockito.version>1.10.19</mockito.version>
         <slf4j.api.version>1.7.30</slf4j.api.version>
 
-        <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
+        <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <commons-csv.version>1.8</commons-csv.version>
         <commons-codec.version>1.14</commons-codec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
 
         <findbugs.version>3.0.1</findbugs.version>
         <guava.version>27.0.1-jre</guava.version>
@@ -29,22 +29,24 @@
         <slf4j.api.version>1.7.25</slf4j.api.version>
 
         <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
-        <commons-lang3.version>3.3.2</commons-lang3.version>
+        <commons-lang3.version>3.11</commons-lang3.version>
         <commons-csv.version>1.4</commons-csv.version>
         <commons-codec.version>1.6</commons-codec.version>
         <commons-io.version>2.4</commons-io.version>
         <org.json-version>20180813</org.json-version>
-        <compiler.plugin.verson>3.8.0</compiler.plugin.verson>
-        <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
+        <enforcer.plugin.version>3.0.0-M3</enforcer.plugin.version>
+        <compiler.plugin.verson>3.8.1</compiler.plugin.verson>
         <gpg.plugin.version>1.6</gpg.plugin.version>
         <jacoco.plugin.version>0.7.7.201606060606</jacoco.plugin.version>
-        <jar.plugin.version>2.4</jar.plugin.version>
-        <javadoc.plugin.version>2.10.3</javadoc.plugin.version>
+        <jar.plugin.version>3.2.0</jar.plugin.version>
+        <javadoc.plugin.version>3.2.0</javadoc.plugin.version>
+        <minimum.maven.version>3.3.9</minimum.maven.version>
         <nexus.plugin.version>1.6.7</nexus.plugin.version>
         <release.plugin.version>2.5.3</release.plugin.version>
         <scm.plugin.version>1.1</scm.plugin.version>
         <source.plugin.version>2.4</source.plugin.version>
-        <surefire.plugin.version>2.22.1</surefire.plugin.version>
+        <spotbugs.plugin.version>4.0.4</spotbugs.plugin.version>
+        <surefire.plugin.version>3.0.0-M5</surefire.plugin.version>
         <class-path-scanner.version>2.10.0</class-path-scanner.version>
 
 
@@ -202,6 +204,26 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${enforcer.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>${minimum.maven.version}</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>${release.plugin.version}</version>
                 <configuration>
@@ -241,16 +263,17 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${findbugs.plugin.version}</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${spotbugs.plugin.version}</version>
                 <configuration>
                     <effort>Low</effort>
                     <threshold>Low</threshold>
                     <xmlOutput>true</xmlOutput>
-                    <findbugsXmlOutputDirectory>
-                        ${project.build.directory}/findbugs
-                    </findbugsXmlOutputDirectory>
+                    <spotbugsXmlOutputDirectory>
+                        ${project.build.directory}/spotbugs
+                    </spotbugsXmlOutputDirectory>
+                    <spotbugsXmlOutputFilename>findbugs.xml</spotbugsXmlOutputFilename>
                 </configuration>
                 <executions>
                     <execution>
@@ -263,9 +286,10 @@
                             <effort>Low</effort>
                             <threshold>Low</threshold>
                             <xmlOutput>true</xmlOutput>
-                            <findbugsXmlOutputDirectory>
-                                ${project.build.directory}/findbugs
-                            </findbugsXmlOutputDirectory>
+                            <spotbugsXmlOutputDirectory>
+                                ${project.build.directory}/spotbugs
+                            </spotbugsXmlOutputDirectory>
+                            <spotbugsXmlOutputFilename>findbugs.xml</spotbugsXmlOutputFilename>
                         </configuration>
                     </execution>
                 </executions>
@@ -316,7 +340,6 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${javadoc.plugin.version}</version>
                 <configuration>
-                    <aggregate>true</aggregate>
                     <show>public</show>
                     <nohelp>true</nohelp>
                     <header>Koryphe ${project.version}</header>
@@ -537,9 +560,9 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
-                        <version>${findbugs.plugin.version}</version>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <version>${spotbugs.plugin.version}</version>
                         <configuration>
                             <fork>false</fork>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -19,35 +19,36 @@
     <properties>
         <java.version>11</java.version>
 
-        <findbugs.version>3.0.1</findbugs.version>
-        <guava.version>27.0.1-jre</guava.version>
+        <findbugs.annotations.version>3.0.1u2</findbugs.annotations.version>
+        <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
+        <guava.version>29.0-jre</guava.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jackson.version>2.6.5</jackson.version>
-        <junit5.version>5.6.0</junit5.version>
-        <junitSurefireProvider.version>1.1.0</junitSurefireProvider.version>
-        <mockito.version>1.9.5</mockito.version>
-        <slf4j.api.version>1.7.25</slf4j.api.version>
+        <jackson.version>2.6.7</jackson.version>
+        <junit5.version>5.6.2</junit5.version>
+        <junitSurefireProvider.version>1.3.2</junitSurefireProvider.version>
+        <mockito.version>1.10.19</mockito.version>
+        <slf4j.api.version>1.7.30</slf4j.api.version>
 
         <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
         <commons-lang3.version>3.11</commons-lang3.version>
-        <commons-csv.version>1.4</commons-csv.version>
-        <commons-codec.version>1.6</commons-codec.version>
-        <commons-io.version>2.4</commons-io.version>
-        <org.json-version>20180813</org.json-version>
+        <commons-csv.version>1.8</commons-csv.version>
+        <commons-codec.version>1.14</commons-codec.version>
+        <commons-io.version>2.7</commons-io.version>
+        <org.json.version>20200518</org.json.version>
         <enforcer.plugin.version>3.0.0-M3</enforcer.plugin.version>
         <compiler.plugin.verson>3.8.1</compiler.plugin.verson>
         <gpg.plugin.version>1.6</gpg.plugin.version>
-        <jacoco.plugin.version>0.7.7.201606060606</jacoco.plugin.version>
+        <jacoco.plugin.version>0.8.5</jacoco.plugin.version>
         <jar.plugin.version>3.2.0</jar.plugin.version>
         <javadoc.plugin.version>3.2.0</javadoc.plugin.version>
         <minimum.maven.version>3.3.9</minimum.maven.version>
-        <nexus.plugin.version>1.6.7</nexus.plugin.version>
-        <release.plugin.version>2.5.3</release.plugin.version>
-        <scm.plugin.version>1.1</scm.plugin.version>
-        <source.plugin.version>2.4</source.plugin.version>
+        <nexus.plugin.version>1.6.8</nexus.plugin.version>
+        <release.plugin.version>3.0.0-M1</release.plugin.version>
+        <scm.plugin.version>3.0.0</scm.plugin.version>
+        <source.plugin.version>3.2.1</source.plugin.version>
         <spotbugs.plugin.version>4.0.4</spotbugs.plugin.version>
         <surefire.plugin.version>3.0.0-M5</surefire.plugin.version>
-        <class-path-scanner.version>2.10.0</class-path-scanner.version>
+        <class-path-scanner.version>3.1.12</class-path-scanner.version>
 
 
         <!-- Define SCM properties for use with Release Plugin -->
@@ -103,12 +104,12 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
-            <version>${findbugs.version}</version>
+            <version>${findbugs.annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>${findbugs.version}</version>
+            <version>${findbugs.jsr305.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.lukehutch</groupId>
@@ -196,7 +197,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>${org.json-version}</version>
+            <version>${org.json.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <jackson.version>2.6.7</jackson.version>
         <junit5.version>5.6.2</junit5.version>
         <junitSurefireProvider.version>1.3.2</junitSurefireProvider.version>
-        <mockito.version>1.10.19</mockito.version>
+        <mockito.version>3.3.3</mockito.version>
         <slf4j.api.version>1.7.30</slf4j.api.version>
 
         <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
@@ -178,7 +178,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Please review the changes to Koryphe to bring the code up to Java 11 level.

Java version has been set to 11.
All plugins and dependencies have been moved up to the most recent stable release versions (ignoring release candidates and very recent versions with low usage figures).

Checkstyle has been brought up to the most recent version. This has necessitated some changes to the checkstyle.xml configuration file to eliminate deprecated options.
Where checkstyle modules have been tightened up some main code code changes have been made to allow the checkstyle checks to pass -  these are mainly RedundantModifier module checks for the 'final' modifier.

There has been no attempt to (Java 9) modularise Koryphe at this time.