### PR TITLE
Gh 195 improve equals checking (#199)

### DIFF
--- a/core/src/main/java/uk/gov/gchq/koryphe/ValidationResult.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/ValidationResult.java
@@ -18,6 +18,8 @@ package uk.gov.gchq.koryphe;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,6 +103,32 @@ public class ValidationResult {
     @JsonIgnore
     public String getErrorString() {
         return "Validation errors: " + System.lineSeparator() + StringUtils.join(getErrors(), System.lineSeparator());
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ValidationResult that = (ValidationResult) o;
+
+        return new EqualsBuilder()
+                .append(isValid, that.isValid)
+                .append(errors, that.errors)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 67)
+                .append(isValid)
+                .append(errors)
+                .toHashCode();
     }
 
     @Override

--- a/core/src/main/java/uk/gov/gchq/koryphe/adapted/InputAdapted.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/adapted/InputAdapted.java
@@ -17,22 +17,32 @@
 package uk.gov.gchq.koryphe.adapted;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.function.Function;
 
 /**
  * An <code>InputAdapted</code> class is one that applies a function to it's inputs, allowing it to be applied to
  * different input types. It can also be used to apply a function to values contained within a complex object.
- *
+ * <p>
  * For example, if we wanted to apply the existing predicate <code>(i -&gt; i != null)</code> to validate the existence of
  * member variable <code>value</code> of a context object (co), we could use an <code>InputAdapted</code> predicate with
  * the input adapter function <code>(co -&gt; co.getValue())</code>.
  *
- * @param <I> Input type
+ * @param <I>  Input type
  * @param <AI> Type adapted from input
  */
 public class InputAdapted<I, AI> {
     protected Function<I, AI> inputAdapter;
+
+    public InputAdapted() {
+        // Required for serialisation
+    }
+
+    public InputAdapted(final Function<I, AI> inputAdapter) {
+        this.inputAdapter = inputAdapter;
+    }
 
     public Function<I, AI> getInputAdapter() {
         return inputAdapter;
@@ -51,5 +61,29 @@ public class InputAdapted<I, AI> {
      */
     protected AI adaptInput(final I input) {
         return inputAdapter == null ? (AI) input : inputAdapter.apply(input);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || !getClass().equals(o.getClass())) {
+            return false;
+        }
+
+        final InputAdapted that = (InputAdapted) o;
+        return new EqualsBuilder()
+                .append(inputAdapter, that.inputAdapter)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(53, 59)
+                .append(getClass())
+                .append(inputAdapter)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/adapted/StateAgnosticOutputAdapter.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/adapted/StateAgnosticOutputAdapter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.koryphe.adapted;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import uk.gov.gchq.koryphe.Since;
+import uk.gov.gchq.koryphe.Summary;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * A {@code StateAgnosticOutputAdapter} is a {@link BiFunction} which ignores the first argument (the state)
+ * and applies a provided function to the output. By default the output is returned.
+ * @param <T> The type of the unused state
+ * @param <U> The type of the input
+ * @param <R> The type of the output
+ */
+@Since("1.11.0")
+@Summary("Adapts an output without considering the state")
+public class StateAgnosticOutputAdapter<T, U, R> implements BiFunction<T, U, R> {
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
+    private Function<U, R> adapter;
+
+    public StateAgnosticOutputAdapter() {
+        // required for Json Serialisation
+    }
+
+    public StateAgnosticOutputAdapter(final Function<U, R> adapter) {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public R apply(final T ignoredState, final U output) {
+        if (adapter == null) {
+            return (R) output;
+        }
+        return adapter.apply(output);
+    }
+
+    public Function<U, R> getAdapter() {
+        return adapter;
+    }
+
+    public void setAdapter(final Function<U, R> adapter) {
+        this.adapter = adapter;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final StateAgnosticOutputAdapter that = (StateAgnosticOutputAdapter) o;
+
+        return new EqualsBuilder()
+                .append(adapter, that.adapter)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(53, 67)
+                .append(getClass())
+                .append(adapter)
+                .toHashCode();
+    }
+}

--- a/core/src/main/java/uk/gov/gchq/koryphe/binaryoperator/AdaptedBinaryOperator.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/binaryoperator/AdaptedBinaryOperator.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.binaryoperator;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -35,7 +37,7 @@ import java.util.function.Function;
 @Since("1.0.0")
 @Summary("Applies a function and adapts the input/output")
 public class AdaptedBinaryOperator<T, OT> extends Adapted<T, OT, OT, T, T> implements BinaryOperator<T> {
-    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
+
     protected BinaryOperator<OT> binaryOperator;
 
     /**
@@ -69,6 +71,9 @@ public class AdaptedBinaryOperator<T, OT> extends Adapted<T, OT, OT, T, T> imple
      */
     @Override
     public T apply(final T state, final T input) {
+        if (binaryOperator == null) {
+            throw new IllegalArgumentException("BinaryOperator cannot be null");
+        }
         return adaptOutput(binaryOperator.apply(adaptInput(state), adaptInput(input)), state);
     }
 
@@ -76,7 +81,32 @@ public class AdaptedBinaryOperator<T, OT> extends Adapted<T, OT, OT, T, T> imple
         return binaryOperator;
     }
 
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
     public void setBinaryOperator(final BinaryOperator<OT> binaryOperator) {
         this.binaryOperator = binaryOperator;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        final AdaptedBinaryOperator that = (AdaptedBinaryOperator) o;
+        return new EqualsBuilder()
+                .append(binaryOperator, that.binaryOperator)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(43, 67)
+                .appendSuper(super.hashCode())
+                .append(binaryOperator)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/function/AdaptedFunction.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/function/AdaptedFunction.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.function;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.adapted.Adapted;
 
@@ -74,5 +76,29 @@ public abstract class AdaptedFunction<I, FI, FO, O> extends Adapted<I, FI, FO, O
 
     public void setFunction(final Function<FI, FO> function) {
         this.function = function;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        final AdaptedFunction that = (AdaptedFunction) o;
+        return new EqualsBuilder()
+                .append(function, that.function)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(43, 67)
+                .appendSuper(super.hashCode())
+                .append(function)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/binaryoperator/StringConcat.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/binaryoperator/StringConcat.java
@@ -35,6 +35,14 @@ public class StringConcat extends KorypheBinaryOperator<String> {
     private static final String DEFAULT_SEPARATOR = ",";
     private String separator = DEFAULT_SEPARATOR;
 
+    public StringConcat() {
+        // required for serialisation
+    }
+
+    public StringConcat(final String separator) {
+        this.separator = separator;
+    }
+
     @Override
     public String _apply(final String a, final String b) {
         return a + separator + b;

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ApplyBiFunction.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ApplyBiFunction.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.impl.function;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -62,5 +64,29 @@ public class ApplyBiFunction<T, U, R> extends KorypheFunction2<T, U, R> implemen
 
     public void setFunction(final BiFunction<T, U, R> function) {
         this.function = function;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        ApplyBiFunction<?, ?, ?> that = (ApplyBiFunction<?, ?, ?>) o;
+        return new EqualsBuilder()
+                .append(function, that.function)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(11, 89)
+                .appendSuper(super.hashCode())
+                .append(function)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/CallMethod.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/CallMethod.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -85,5 +88,29 @@ public class CallMethod extends KorypheFunction<Object, Object> {
         } catch (final NoSuchMethodException e) {
             throw new RuntimeException("Unable to invoke " + getMethod() + " on object class " + clazz, e);
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        CallMethod that = (CallMethod) o;
+        return new EqualsBuilder()
+                .append(method, that.method)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(23, 67)
+                .appendSuper(super.hashCode())
+                .append(method)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/Cast.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/Cast.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -49,5 +52,29 @@ public class Cast<I, O> extends KorypheFunction<I, O> {
 
     public void setOutputClass(final Class<O> outputClass) {
         this.outputClass = outputClass;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        Cast that = (Cast) o;
+        return new EqualsBuilder()
+                .append(outputClass, that.outputClass)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(7, 37)
+                .appendSuper(super.hashCode())
+                .append(outputClass)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/CreateObject.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/CreateObject.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -79,5 +82,29 @@ public class CreateObject extends KorypheFunction<Object, Object> {
 
     public void setObjectClass(final Class<?> objectClass) {
         this.objectClass = objectClass;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        CreateObject that = (CreateObject) o;
+        return new EqualsBuilder()
+                .append(objectClass, that.objectClass)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(3, 29)
+                .appendSuper(super.hashCode())
+                .append(objectClass)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/CsvLinesToMaps.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/CsvLinesToMaps.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -177,5 +179,37 @@ public class CsvLinesToMaps extends KorypheFunction<Iterable<String>, Iterable<M
     public CsvLinesToMaps quoteChar(final char quoteChar) {
         this.quoteChar = quoteChar;
         return this;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        CsvLinesToMaps that = (CsvLinesToMaps) o;
+        return new EqualsBuilder()
+                .append(header, that.header)
+                .append(quoted, that.quoted)
+                .append(quoteChar, that.quoteChar)
+                .append(firstRow, that.firstRow)
+                .append(delimiter, that.delimiter)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(7, 19)
+                .appendSuper(super.hashCode())
+                .append(header)
+                .append(quoted)
+                .append(quoteChar)
+                .append(firstRow)
+                .append(delimiter)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/CsvToMaps.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/CsvToMaps.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -161,4 +163,36 @@ public class CsvToMaps extends KorypheFunction<String, Iterable<Map<String, Obje
         this.quoteChar = quoteChar;
         return this;
     }
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        CsvToMaps that = (CsvToMaps) o;
+        return new EqualsBuilder()
+                .append(header, that.header)
+                .append(quoted, that.quoted)
+                .append(quoteChar, that.quoteChar)
+                .append(firstRow, that.firstRow)
+                .append(delimiter, that.delimiter)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(7, 23)
+                .appendSuper(super.hashCode())
+                .append(header)
+                .append(quoted)
+                .append(quoteChar)
+                .append(firstRow)
+                .append(delimiter)
+                .toHashCode();
+    }
+
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/DefaultIfEmpty.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/DefaultIfEmpty.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -29,7 +32,7 @@ import uk.gov.gchq.koryphe.function.KorypheFunction;
 public class DefaultIfEmpty extends KorypheFunction<Object, Object> {
 
     private Object defaultValue;
-    private Length delegate = new Length();
+    private final Length delegate = new Length();
 
     public DefaultIfEmpty() {
     }
@@ -53,5 +56,29 @@ public class DefaultIfEmpty extends KorypheFunction<Object, Object> {
 
     public void setDefaultValue(final Object defaultValue) {
         this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        DefaultIfEmpty that = (DefaultIfEmpty) o;
+        return new EqualsBuilder()
+                .append(defaultValue, that.defaultValue)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(23, 17)
+                .appendSuper(super.hashCode())
+                .append(defaultValue)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/DefaultIfNull.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/DefaultIfNull.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -47,5 +50,29 @@ public class DefaultIfNull extends KorypheFunction<Object, Object> {
 
     public Object getDefaultValue() {
         return defaultValue;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        DefaultIfNull that = (DefaultIfNull) o;
+        return new EqualsBuilder()
+                .append(defaultValue, that.defaultValue)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(5, 51)
+                .appendSuper(super.hashCode())
+                .append(defaultValue)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/DeserialiseJson.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/DeserialiseJson.java
@@ -19,6 +19,8 @@ package uk.gov.gchq.koryphe.impl.function;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -82,5 +84,29 @@ public class DeserialiseJson<T> extends KorypheFunction<String, T> implements Se
         } else {
             this.outputClass = outputClass;
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        DeserialiseJson that = (DeserialiseJson) o;
+        return new EqualsBuilder()
+                .append(outputClass, that.outputClass)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(43, 31)
+                .appendSuper(super.hashCode())
+                .append(outputClass)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/DictionaryLookup.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/DictionaryLookup.java
@@ -15,6 +15,9 @@
  */
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -51,5 +54,29 @@ public class DictionaryLookup<K, V> extends KorypheFunction<K, V> {
 
     public void setDictionary(final Map<K, V> dictionary) {
         this.dictionary = dictionary;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        DictionaryLookup that = (DictionaryLookup) o;
+        return new EqualsBuilder()
+                .append(dictionary, that.dictionary)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(13, 53)
+                .appendSuper(super.hashCode())
+                .append(dictionary)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/DivideBy.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/DivideBy.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -55,5 +58,29 @@ public class DivideBy extends KorypheFunction<Integer, Tuple2<Integer, Integer>>
         } else {
             return new Tuple2<>(input / by, input % by);
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        DivideBy that = (DivideBy) o;
+        return new EqualsBuilder()
+                .append(by, that.by)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(47, 59)
+                .appendSuper(super.hashCode())
+                .append(by)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ExtractValue.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ExtractValue.java
@@ -15,6 +15,9 @@
  */
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -50,5 +53,29 @@ public class ExtractValue<K, V> extends KorypheFunction<Map<K, V>, V> {
     @Override
     public V apply(final Map<K, V> map) {
         return null == map ? null : map.get(key);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        ExtractValue that = (ExtractValue) o;
+        return new EqualsBuilder()
+                .append(key, that.key)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(11, 41)
+                .appendSuper(super.hashCode())
+                .append(key)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/FirstValid.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/FirstValid.java
@@ -18,6 +18,8 @@ package uk.gov.gchq.koryphe.impl.function;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.Iterables;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -71,5 +73,29 @@ public class FirstValid<I_ITEM> extends KorypheFunction<Iterable<I_ITEM>, I_ITEM
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
     public Predicate getPredicate() {
         return predicate;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        FirstValid that = (FirstValid) o;
+        return new EqualsBuilder()
+                .append(predicate, that.predicate)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(37, 83)
+                .appendSuper(super.hashCode())
+                .append(predicate)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/Increment.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/Increment.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.impl.function;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -112,6 +114,31 @@ public class Increment extends KorypheFunction<Number, Number> {
         } else {
             type = null;
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        Increment that = (Increment) o;
+        return new EqualsBuilder()
+                .append(increment, that.increment)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(59, 83)
+                .appendSuper(super.hashCode())
+                .append(increment)
+                .append(increment == null ? null : increment.getClass())
+                .toHashCode();
     }
 
     private enum Type {

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/IterableFilter.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/IterableFilter.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.impl.function;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -64,5 +66,29 @@ public class IterableFilter<I_ITEM> extends KorypheFunction<Iterable<I_ITEM>, It
     public IterableFilter<I_ITEM> setPredicate(final Predicate<I_ITEM> predicate) {
         this.predicate = predicate;
         return this;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        IterableFilter that = (IterableFilter) o;
+        return new EqualsBuilder()
+                .append(predicate, that.predicate)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(3, 97)
+                .appendSuper(super.hashCode())
+                .append(predicate)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/IterableFlatten.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/IterableFlatten.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.impl.function;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -66,5 +68,29 @@ public class IterableFlatten<I_ITEM> extends KorypheFunction<Iterable<I_ITEM>, I
 
     public void setOperator(final BinaryOperator<I_ITEM> operator) {
         this.operator = operator;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        IterableFlatten that = (IterableFlatten) o;
+        return new EqualsBuilder()
+                .append(operator, that.operator)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(31, 59)
+                .appendSuper(super.hashCode())
+                .append(operator)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/Length.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/Length.java
@@ -16,6 +16,8 @@
 package uk.gov.gchq.koryphe.impl.function;
 
 import com.google.common.collect.Iterables;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -37,6 +39,10 @@ public class Length extends KorypheFunction<Object, Integer> implements InputVal
 
     public Length() {
         // For Serialisation
+    }
+
+    public Length(final Integer maxLength) {
+        this.maxLength = maxLength;
     }
 
     @Override
@@ -96,5 +102,29 @@ public class Length extends KorypheFunction<Object, Integer> implements InputVal
 
     public void setMaxLength(final Integer maxLength) {
         this.maxLength = maxLength;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        Length that = (Length) o;
+        return new EqualsBuilder()
+                .append(maxLength, that.maxLength)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(43, 67)
+                .appendSuper(super.hashCode())
+                .append(maxLength)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/MapFilter.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/MapFilter.java
@@ -17,6 +17,9 @@
 package uk.gov.gchq.koryphe.impl.function;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -110,5 +113,42 @@ public class MapFilter<K, V> extends KorypheFunction<Map<K, V>, Map<K, V>> {
         }
 
         removeIfPredicate = filter.negate();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        MapFilter that = (MapFilter) o;
+        return new EqualsBuilder()
+                .append(keyPredicate, that.keyPredicate)
+                .append(valuePredicate, that.valuePredicate)
+                .append(keyValuePredicate, that.keyValuePredicate)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(13, 79)
+                .appendSuper(super.hashCode())
+                .append(keyPredicate)
+                .append(valuePredicate)
+                .append(keyValuePredicate)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("keyPredicate", keyPredicate)
+                .append("valuePredicate", valuePredicate)
+                .append("keyValuePredicate", keyValuePredicate)
+                .toString();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/MultiplyBy.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/MultiplyBy.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -51,5 +54,29 @@ public class MultiplyBy extends KorypheFunction<Integer, Integer> {
         } else {
             return input * by;
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        MultiplyBy that = (MultiplyBy) o;
+        return new EqualsBuilder()
+                .append(by, that.by)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(73, 29)
+                .appendSuper(super.hashCode())
+                .append(by)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/MultiplyLongBy.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/MultiplyLongBy.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -51,5 +54,29 @@ public class MultiplyLongBy extends KorypheFunction<Long, Long> {
         } else {
             return input * by;
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        MultiplyLongBy that = (MultiplyLongBy) o;
+        return new EqualsBuilder()
+                .append(by, that.by)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(83, 11)
+                .appendSuper(super.hashCode())
+                .append(by)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/NthItem.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/NthItem.java
@@ -17,6 +17,8 @@ package uk.gov.gchq.koryphe.impl.function;
 
 import com.google.common.collect.Iterables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -62,5 +64,29 @@ public class NthItem<T> extends KorypheFunction<Iterable<T>, T> {
 
     public int getSelection() {
         return selection;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        NthItem that = (NthItem) o;
+        return new EqualsBuilder()
+                .append(selection, that.selection)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(67, 23)
+                .appendSuper(super.hashCode())
+                .append(selection)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ParseDate.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ParseDate.java
@@ -17,6 +17,8 @@ package uk.gov.gchq.koryphe.impl.function;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -110,5 +112,31 @@ public class ParseDate extends KorypheFunction<String, Date> {
     public ParseDate timeZone(final TimeZone timeZone) {
         setTimeZone(timeZone);
         return this;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        ParseDate that = (ParseDate) o;
+        return new EqualsBuilder()
+                .append(timeZone, that.timeZone)
+                .append(format, that.format)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(73, 41)
+                .appendSuper(super.hashCode())
+                .append(timeZone)
+                .append(format)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ParseTime.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ParseTime.java
@@ -17,6 +17,8 @@ package uk.gov.gchq.koryphe.impl.function;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -139,6 +141,34 @@ public class ParseTime extends KorypheFunction<String, Long> {
     public ParseTime timeUnit(final TimeUnit timeUnit) {
         setTimeUnit(timeUnit);
         return this;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        ParseTime that = (ParseTime) o;
+        return new EqualsBuilder()
+                .append(timeZone, that.timeZone)
+                .append(format, that.format)
+                .append(timeUnit, that.timeUnit)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(29, 61)
+                .appendSuper(super.hashCode())
+                .append(timeZone)
+                .append(format)
+                .append(timeUnit)
+                .toHashCode();
     }
 
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/SetValue.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/SetValue.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.impl.function;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -52,5 +54,29 @@ public class SetValue extends KorypheFunction<Object, Object> {
 
     public void setValue(final Object identity) {
         this.value = identity;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        SetValue that = (SetValue) o;
+        return new EqualsBuilder()
+                .append(value, that.value)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 47)
+                .appendSuper(super.hashCode())
+                .append(value)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringAppend.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringAppend.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.impl.function;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -62,5 +64,29 @@ public class StringAppend extends KorypheFunction<String, String> {
         } else {
             this.suffix = suffix;
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        StringAppend that = (StringAppend) o;
+        return new EqualsBuilder()
+                .append(suffix, that.suffix)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(13, 37)
+                .appendSuper(super.hashCode())
+                .append(suffix)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringJoin.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringJoin.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.impl.function;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -56,5 +58,29 @@ public class StringJoin<I_ITEM> extends KorypheFunction<Iterable<I_ITEM>, String
 
     public void setDelimiter(final String delimiter) {
         this.delimiter = delimiter;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        StringJoin that = (StringJoin) o;
+        return new EqualsBuilder()
+                .append(delimiter, that.delimiter)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(53, 73)
+                .appendSuper(super.hashCode())
+                .append(delimiter)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringPrepend.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringPrepend.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.impl.function;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -60,5 +62,29 @@ public class StringPrepend extends KorypheFunction<String, String> {
         } else {
             this.prefix = prefix;
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        StringPrepend that = (StringPrepend) o;
+        return new EqualsBuilder()
+                .append(prefix, that.prefix)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(63, 37)
+                .appendSuper(super.hashCode())
+                .append(prefix)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringRegexReplace.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringRegexReplace.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -65,5 +68,31 @@ public class StringRegexReplace extends KorypheFunction<String, String> {
 
     public void setReplacement(final String replacement) {
         this.replacement = replacement;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        StringRegexReplace that = (StringRegexReplace) o;
+        return new EqualsBuilder()
+                .append(regex, that.regex)
+                .append(replacement, that.replacement)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(83, 29)
+                .appendSuper(super.hashCode())
+                .append(regex)
+                .append(replacement)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringRegexSplit.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringRegexSplit.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -59,5 +62,29 @@ public class StringRegexSplit extends KorypheFunction<String, List<String>> {
 
     public void setRegex(final String regex) {
         this.regex = regex;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        StringRegexSplit that = (StringRegexSplit) o;
+        return new EqualsBuilder()
+                .append(regex, that.regex)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(53, 59)
+                .appendSuper(super.hashCode())
+                .append(regex)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringReplace.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringReplace.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.impl.function;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -61,5 +63,31 @@ public class StringReplace extends KorypheFunction<String, String> {
 
     public void setSearchString(final String searchString) {
         this.searchString = searchString;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        StringReplace that = (StringReplace) o;
+        return new EqualsBuilder()
+                .append(searchString, that.searchString)
+                .append(replacement, that.replacement)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(71, 53)
+                .appendSuper(super.hashCode())
+                .append(searchString)
+                .append(replacement)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringSplit.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringSplit.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.impl.function;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -60,5 +62,29 @@ public class StringSplit extends KorypheFunction<String, List<String>> {
 
     public void setDelimiter(final String delimiter) {
         this.delimiter = delimiter;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        StringSplit that = (StringSplit) o;
+        return new EqualsBuilder()
+                .append(delimiter, that.delimiter)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(53, 73)
+                .appendSuper(super.hashCode())
+                .append(delimiter)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringTruncate.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/StringTruncate.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -72,5 +75,31 @@ public class StringTruncate extends KorypheFunction<String, String> {
 
     public void setEllipses(final boolean ellipses) {
         this.ellipses = ellipses;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        StringTruncate that = (StringTruncate) o;
+        return new EqualsBuilder()
+                .append(length, that.length)
+                .append(ellipses, that.ellipses)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(73, 61)
+                .appendSuper(super.hashCode())
+                .append(length)
+                .append(ellipses)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToBytes.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToBytes.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.google.common.base.Charsets;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -80,5 +82,29 @@ public class ToBytes extends KorypheFunction<String, byte[]> {
     @JsonGetter("charset")
     public String getCharsetAsString() {
         return charset.name();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        ToBytes that = (ToBytes) o;
+        return new EqualsBuilder()
+                .append(charset, that.charset)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(5, 83)
+                .appendSuper(super.hashCode())
+                .append(charset)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToDateString.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToDateString.java
@@ -16,6 +16,9 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -61,5 +64,30 @@ public class ToDateString extends KorypheFunction<Date, String> {
 
     public void setFormat(final String format) {
         this.format = format;
+    }
+
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        ToDateString that = (ToDateString) o;
+        return new EqualsBuilder()
+                .append(format, that.format)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(61, 47)
+                .appendSuper(super.hashCode())
+                .append(format)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToString.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToString.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.google.common.base.Charsets;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -83,5 +85,29 @@ public class ToString extends KorypheFunction<Object, String> {
     @JsonGetter("charset")
     public String getCharsetAsString() {
         return charset.name();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does exact equals and class checking
+        }
+
+        ToString that = (ToString) o;
+        return new EqualsBuilder()
+                .append(charset, that.charset)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(43, 67)
+                .appendSuper(super.hashCode())
+                .append(charset)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/predicate/IsA.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/predicate/IsA.java
@@ -80,7 +80,7 @@ public class IsA extends KoryphePredicate<Object> {
      * Tests whether the argument supplied is an instance of the control class.
      *
      * @param input {@link Object} to test.
-     * @return true iff input is null or non-null and can be cast to the control class, otherwise false.
+     * @return true if input is null or non-null and can be cast to the control class, otherwise false.
      */
     @Override
     public boolean test(final Object input) {

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/predicate/MultiRegex.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/predicate/MultiRegex.java
@@ -42,10 +42,10 @@ public class MultiRegex extends KoryphePredicate<String> {
     private Pattern[] patterns;
 
     public MultiRegex() {
-        this(null);
+        this((Pattern[]) null);
     }
 
-    public MultiRegex(final Pattern[] patterns) {
+    public MultiRegex(final Pattern... patterns) {
         setPatterns(patterns);
     }
 

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/predicate/Regex.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/predicate/Regex.java
@@ -76,16 +76,18 @@ public class Regex extends KoryphePredicate<String> {
         }
 
         final Regex regex = (Regex) obj;
+
         return new EqualsBuilder()
-                .append(controlValue.toString(), regex.controlValue.toString())
+                .append(controlValue != null ? controlValue.toString() : null,
+                        regex.controlValue != null ? regex.controlValue.toString() : null)
                 .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
+        return new HashCodeBuilder(43, 97)
                 // Pattern does not override hashCode()
-                .append(controlValue.toString())
+                .append(controlValue != null ? controlValue.toString() : null)
                 .toHashCode();
     }
 

--- a/core/src/main/java/uk/gov/gchq/koryphe/predicate/AdaptedPredicate.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/predicate/AdaptedPredicate.java
@@ -17,6 +17,8 @@
 package uk.gov.gchq.koryphe.predicate;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -66,5 +68,29 @@ public class AdaptedPredicate<I, PI> extends InputAdapted<I, PI> implements Pred
 
     public void setPredicate(final Predicate<PI> predicate) {
         this.predicate = predicate;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        final AdaptedPredicate that = (AdaptedPredicate) o;
+        return new EqualsBuilder()
+                .append(predicate, that.predicate)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(43, 67)
+                .appendSuper(super.hashCode())
+                .append(predicate)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/TupleInputAdapter.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/TupleInputAdapter.java
@@ -17,12 +17,14 @@
 package uk.gov.gchq.koryphe.tuple;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
+import uk.gov.gchq.koryphe.function.KorypheFunction;
 
 import java.util.Arrays;
-import java.util.function.Function;
 
 /**
  * @param <R>  The type of reference used by tuples.
@@ -30,7 +32,7 @@ import java.util.function.Function;
  */
 @Since("1.0.0")
 @Summary("Extracts items from a tuple")
-public class TupleInputAdapter<R, FI> implements Function<Tuple<R>, FI> {
+public class TupleInputAdapter<R, FI> extends KorypheFunction<Tuple<R>, FI> {
     private R[] selection;
 
     /**
@@ -83,5 +85,29 @@ public class TupleInputAdapter<R, FI> implements Function<Tuple<R>, FI> {
         } else {
             this.selection = selection;
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!super.equals(o)) {
+            return false; // Does class checking
+        }
+
+        final TupleInputAdapter that = (TupleInputAdapter) o;
+        return new EqualsBuilder()
+                .append(selection, that.selection)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(43, 67)
+                .appendSuper(super.hashCode())
+                .append(selection)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/TupleOutputAdapter.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/TupleOutputAdapter.java
@@ -16,7 +16,13 @@
 
 package uk.gov.gchq.koryphe.tuple;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import uk.gov.gchq.koryphe.Since;
+import uk.gov.gchq.koryphe.Summary;
 
 import java.util.Arrays;
 import java.util.function.BiFunction;
@@ -25,6 +31,9 @@ import java.util.function.BiFunction;
  * @param <R>  The type of reference used by tuples.
  * @param <FO> The adapted output type.
  */
+@Since("1.0.0")
+@Summary("Projects items to a tuple")
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
 public class TupleOutputAdapter<R, FO> implements BiFunction<Tuple<R>, FO, Tuple<R>> {
     private R[] projection;
 
@@ -83,5 +92,29 @@ public class TupleOutputAdapter<R, FO> implements BiFunction<Tuple<R>, FO, Tuple
      */
     public R[] getProjection() {
         return Arrays.copyOf(projection, projection.length);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || !getClass().equals(o.getClass())) {
+            return false;
+        }
+
+        final TupleOutputAdapter that = (TupleOutputAdapter) o;
+        return new EqualsBuilder()
+                .append(projection, that.projection)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(43, 67)
+                .append(getClass().hashCode())
+                .append(projection)
+                .toHashCode();
     }
 }

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/n/Tuple1.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/n/Tuple1.java
@@ -17,7 +17,7 @@
 package uk.gov.gchq.koryphe.tuple.n;
 
 /**
- * An {@link TupleN} containing 2 entries.
+ * An {@link TupleN} containing 1 entry.
  *
  * @param <A> Type of the entry at index 0.
  */

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/n/TupleN.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/n/TupleN.java
@@ -19,7 +19,7 @@ package uk.gov.gchq.koryphe.tuple.n;
 import uk.gov.gchq.koryphe.tuple.ArrayTuple;
 
 /**
- * An {@link ArrayTuple} containing 5 entries.
+ * An {@link ArrayTuple} containing any number of entries.
  */
 public class TupleN extends ArrayTuple {
     public TupleN(final int size) {

--- a/core/src/main/java/uk/gov/gchq/koryphe/tuple/predicate/IntegerTupleAdaptedPredicate.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/tuple/predicate/IntegerTupleAdaptedPredicate.java
@@ -17,7 +17,6 @@
 package uk.gov.gchq.koryphe.tuple.predicate;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
@@ -29,7 +28,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Predicate;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
 @JsonPropertyOrder(value = {"class", "selection", "predicate"}, alphabetic = true)
 @Since("1.0.0")
 @Summary("Applies a predicate and adapts an input integer tuple")

--- a/core/src/test/java/uk/gov/gchq/koryphe/ValidationResultTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/ValidationResultTest.java
@@ -1,0 +1,113 @@
+package uk.gov.gchq.koryphe;
+
+import com.google.common.collect.Sets;
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.util.EqualityTest;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ValidationResultTest extends EqualityTest<ValidationResult> {
+    @Override
+    protected ValidationResult getInstance() {
+        return new ValidationResult();
+    }
+
+    @Override
+    protected Iterable<ValidationResult> getDifferentInstancesOrNull() {
+        ValidationResult twoErrors = new ValidationResult("Something went wrong");
+
+        twoErrors.addError("another thing went wrong");
+
+        return Arrays.asList(
+                new ValidationResult("Something broke"),
+                twoErrors
+        );
+    }
+
+    @Test
+    public void shouldInitiallyBeValid() {
+        // Given
+        ValidationResult validationResult = new ValidationResult();
+
+        // When
+        boolean valid = validationResult.isValid();
+
+        // Then
+        assertTrue(valid);
+    }
+
+    @Test
+    public void shouldReturnEmptySetIfValid() {
+        // Given
+        ValidationResult validationResult = new ValidationResult();
+
+        // When
+        Set<String> errors = validationResult.getErrors();
+
+        // Then
+        assertEquals(new HashSet<>(), errors);
+    }
+
+    @Test
+    public void shouldReturnStringForErrorStringIfNoErrorsArePresent() {
+        // Given
+        ValidationResult validationResult = new ValidationResult();
+
+        // When
+        String errorString = validationResult.getErrorString();
+
+        // Then
+        assertEquals("Validation errors: " + System.lineSeparator(), errorString);
+    }
+
+    @Test
+    public void shouldDeduplicateErrors() {
+        // Given
+        ValidationResult validationResult = new ValidationResult();
+        validationResult.addError("err");
+        validationResult.addError("err");
+
+        // When
+        Set<String> errors = validationResult.getErrors();
+
+        assertEquals(1, errors.size());
+    }
+
+    @Test
+    public void shouldListAllUniqueErrors() {
+        // Given
+        ValidationResult validationResult = new ValidationResult();
+        validationResult.addError("err");
+        validationResult.addError("different error");
+
+        // When
+        Set<String> errors = validationResult.getErrors();
+
+        // Then
+        assertEquals(2, errors.size());
+        HashSet<String> expected = Sets.newHashSet("err", "different error");
+
+        assertEquals(expected, errors);
+    }
+
+    @Test
+    public void shouldSeparateAllTheErrorsUsingTheSystemLineSeparator() {
+        // Given
+        String lineSeparator = System.lineSeparator();
+        ValidationResult validationResult = new ValidationResult();
+        validationResult.addError("err");
+        validationResult.addError("different error");
+
+        // When
+        String errorString = validationResult.getErrorString();
+
+        // Then
+        assertEquals("Validation errors: " + lineSeparator + "err" + lineSeparator + "different error", errorString);
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/adapted/InputAdaptedTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/adapted/InputAdaptedTest.java
@@ -1,0 +1,43 @@
+package uk.gov.gchq.koryphe.adapted;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.impl.function.FunctionChain;
+import uk.gov.gchq.koryphe.impl.function.ToLong;
+import uk.gov.gchq.koryphe.impl.function.ToString;
+import uk.gov.gchq.koryphe.util.EqualityTest;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InputAdaptedTest extends EqualityTest<InputAdapted> {
+
+    @Override
+    protected InputAdapted getInstance() {
+        return new InputAdapted(new ToLong());
+    }
+
+    @Override
+    protected Iterable<InputAdapted> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new InputAdapted(),
+                new InputAdapted(new ToString()),
+                new InputAdapted(new FunctionChain(new ToLong()))
+        );
+    }
+
+    @Test
+    public void shouldApplyInputAdapterToInput() {
+        // Given
+        Integer input = 5;
+
+        // When
+        InputAdapted<Object, Long> inputAdapted = new InputAdapted<>(new ToLong());
+        Long output = inputAdapted.adaptInput(input);
+
+        // Then
+        assertEquals(Long.class, output.getClass());
+        assertEquals(5L, output);
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/adapted/StateAgnosticOutputAdapterTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/adapted/StateAgnosticOutputAdapterTest.java
@@ -1,0 +1,74 @@
+package uk.gov.gchq.koryphe.adapted;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.impl.function.Identity;
+import uk.gov.gchq.koryphe.impl.function.MultiplyBy;
+import uk.gov.gchq.koryphe.impl.function.ToLong;
+import uk.gov.gchq.koryphe.util.EqualityTest;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StateAgnosticOutputAdapterTest extends EqualityTest<StateAgnosticOutputAdapter> {
+
+    @Override
+    protected StateAgnosticOutputAdapter getInstance() {
+        return new StateAgnosticOutputAdapter(new Identity());
+    }
+
+    @Override
+    protected Iterable<StateAgnosticOutputAdapter> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new StateAgnosticOutputAdapter(),
+                new StateAgnosticOutputAdapter(new ToLong())
+        );
+    }
+
+    @Test
+    public void shouldReturnTheUnadaptedOutputIfNoAdapterIsProvided() {
+        // Given
+        StateAgnosticOutputAdapter<Object, Object, Object> soa = new StateAgnosticOutputAdapter<>();
+
+        // When
+        Object output = soa.apply(null, "input");
+
+        // Then
+        assertEquals("input", output);
+    }
+
+    @Test
+    public void shouldApplyAnOutputAdapter() {
+        // Given
+        StateAgnosticOutputAdapter<Object, Integer, Integer> soa = new StateAgnosticOutputAdapter<>(new MultiplyBy(10));
+
+        // When
+        Object output = soa.apply(null, 10);
+
+        // Then
+        assertEquals(100, output);
+    }
+
+    @Test
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        StateAgnosticOutputAdapter<Object, Integer, Integer> soa = new StateAgnosticOutputAdapter<>(new MultiplyBy(10));
+        String json =
+                "{\n" +
+                    "\"adapter\": {\n" +
+                        "\"class\": \"uk.gov.gchq.koryphe.impl.function.MultiplyBy\",\n" +
+                        "\"by\": 10\n" +
+                    "}\n" +
+                "}";
+        // When
+        String serialised = JsonSerialiser.serialise(soa);
+        StateAgnosticOutputAdapter deserialised = JsonSerialiser.deserialise(json, StateAgnosticOutputAdapter.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(soa, deserialised);
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/binaryoperator/AdaptedBinaryOperatorTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/binaryoperator/AdaptedBinaryOperatorTest.java
@@ -1,0 +1,167 @@
+package uk.gov.gchq.koryphe.binaryoperator;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.impl.binaryoperator.Product;
+import uk.gov.gchq.koryphe.impl.binaryoperator.StringConcat;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Sum;
+import uk.gov.gchq.koryphe.impl.function.DivideBy;
+import uk.gov.gchq.koryphe.impl.function.MultiplyBy;
+import uk.gov.gchq.koryphe.impl.function.MultiplyLongBy;
+import uk.gov.gchq.koryphe.impl.function.ToInteger;
+import uk.gov.gchq.koryphe.impl.function.ToLong;
+import uk.gov.gchq.koryphe.tuple.ArrayTuple;
+import uk.gov.gchq.koryphe.tuple.TupleInputAdapter;
+import uk.gov.gchq.koryphe.tuple.TupleOutputAdapter;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+
+class AdaptedBinaryOperatorTest extends BinaryOperatorTest<AdaptedBinaryOperator> {
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        AdaptedBinaryOperator adaptedBinaryOperator = new AdaptedBinaryOperator(new Product(), new ToLong(), new MultiplyBy(5));
+        String json =
+                "{\n" +
+                        "\"binaryOperator\": {\n" +
+                            "\"class\": \"uk.gov.gchq.koryphe.impl.binaryoperator.Product\"\n" +
+                        "},\n" +
+                        "\"inputAdapter\": {\n" +
+                            "\"class\": \"uk.gov.gchq.koryphe.impl.function.ToLong\"\n" +
+                        "},\n" +
+                        "\"outputAdapter\": {\n" +
+                            "\"class\": \"uk.gov.gchq.koryphe.adapted.StateAgnosticOutputAdapter\",\n" +
+                            "\"adapter\": {\n" +
+                                "\"class\": \"uk.gov.gchq.koryphe.impl.function.MultiplyBy\",\n" +
+                                "\"by\": 5\n" +
+                            "}\n" +
+                        "}\n" +
+                    "}";
+        // When
+        String serialised = JsonSerialiser.serialise(adaptedBinaryOperator);
+        AdaptedBinaryOperator deserialised = JsonSerialiser.deserialise(json, AdaptedBinaryOperator.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(adaptedBinaryOperator, deserialised);
+    }
+
+    @Override
+    protected AdaptedBinaryOperator getInstance() {
+        return new AdaptedBinaryOperator(new Sum(), new ToLong(), new MultiplyBy(5));
+    }
+
+    @Override
+    protected Iterable<AdaptedBinaryOperator> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new AdaptedBinaryOperator(new Product(), new ToLong(), new MultiplyBy(5)),
+                new AdaptedBinaryOperator(new Sum(), new ToInteger(), new MultiplyBy(5)),
+                new AdaptedBinaryOperator(new Sum(), new ToLong(), new DivideBy(5)),
+                new AdaptedBinaryOperator()
+        );
+    }
+
+    @Test
+    public void IfNoOutputAdapterIsSpecifiedShouldReturnNewState() {
+        // Given
+        AdaptedBinaryOperator abo = new AdaptedBinaryOperator(new Product(), new ToLong(), (BinaryOperator<Number>) null);
+
+        // When
+        Object aggregated = abo.apply(2, 5);
+
+        // then
+        assertEquals(10L, aggregated);
+    }
+
+    @Test
+    public void shouldAdaptOutputIfOutputAdapterIsSpecified() {
+        // Given
+        AdaptedBinaryOperator abo = new AdaptedBinaryOperator(new Product(), new ToLong(), new MultiplyLongBy(5L));
+
+        // When
+        Object aggregated = abo.apply(2, 5);
+
+        // then
+        assertEquals(50L, aggregated);
+    }
+
+    @Test
+    public void shouldConsiderStateWhenOutputAdapterIsBiFunction() {
+        // Given
+        ArrayTuple state = new ArrayTuple();
+        state.put(0, "tuple");
+
+        ArrayTuple input = new ArrayTuple();
+        state.put(0, "test");;
+
+        TupleInputAdapter<Integer, String> inputAdapter = new TupleInputAdapter<>();
+        inputAdapter.setSelection(new Integer[] { 0 });
+
+        TupleOutputAdapter<Integer, String> outputAdapter = new TupleOutputAdapter<>();
+        outputAdapter.setProjection(new Integer[] { 0 });
+
+        AdaptedBinaryOperator abo = new AdaptedBinaryOperator(new StringConcat(" "), inputAdapter, outputAdapter);
+
+        // When
+        Object aggregated = abo.apply(state, input);
+
+        // Then
+        ArrayTuple expected = new ArrayTuple();
+        state.put(0, "tuple test");
+
+        assertEquals(expected, aggregated);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfNoBinaryOperatorIsSpecified() {
+        // Given
+        AdaptedBinaryOperator abo = new AdaptedBinaryOperator();
+
+        // When / Then
+
+        try {
+            abo.apply("will", "fail");
+            fail("Expected an exception");
+        } catch (Exception e) {
+            assertNotNull(e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldPassInputDirectlyToBinaryOperatorIfNoInputAdapterIsSpecified() {
+        // Given
+        AdaptedBinaryOperator abo = new AdaptedBinaryOperator(new Product(), null, new MultiplyBy(10));
+
+        // When
+        Object aggregated = abo.apply(2, 5);
+
+        // then
+        assertEquals(Integer.class, aggregated.getClass());
+        assertEquals(100, aggregated);
+    }
+
+    @Test
+    public void shouldJustDelegateToBinaryOperatorIfNoAdaptersAreSpecified() {
+        // Given
+        AdaptedBinaryOperator abo = new AdaptedBinaryOperator(new Product(), null, (BiFunction) null);
+
+        // When
+        Object aggregated = abo.apply(2, 5);
+
+        // then
+        assertEquals(Integer.class, aggregated.getClass());
+        assertEquals(10, aggregated);
+    }
+
+
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/binaryoperator/BinaryOperatorCompositeTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/binaryoperator/BinaryOperatorCompositeTest.java
@@ -1,0 +1,83 @@
+package uk.gov.gchq.koryphe.binaryoperator;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.impl.binaryoperator.Product;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Sum;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+class BinaryOperatorCompositeTest extends BinaryOperatorTest<BinaryOperatorComposite> {
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        BinaryOperatorComposite boc = getInstance();
+        String json = "{" +
+                    "\"operators\": [" +
+                        "{" +
+                            "\"class\": \"uk.gov.gchq.koryphe.impl.binaryoperator.Sum\"" +
+                        "}," +
+                        "{" +
+                            "\"class\": \"uk.gov.gchq.koryphe.impl.binaryoperator.Product\"" +
+                        "}" +
+                    "]" +
+                "}";
+
+        // When
+        String serialised = JsonSerialiser.serialise(boc);
+        BinaryOperatorComposite deserialised = JsonSerialiser.deserialise(json, BinaryOperatorComposite.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(boc, deserialised);
+
+    }
+
+    @Override
+    protected BinaryOperatorComposite getInstance() {
+        return new BinaryOperatorComposite(Arrays.asList(
+                new Sum(),
+                new Product()
+        ));
+    }
+
+    @Override
+    protected Iterable<BinaryOperatorComposite> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new BinaryOperatorComposite(),
+                new BinaryOperatorComposite(Arrays.asList(
+                        new Product(),
+                        new Sum()
+                )),
+                new BinaryOperatorComposite(Arrays.asList(
+                        new Sum(),
+                        new Sum()
+                ))
+        );
+    }
+
+    @Test
+    public void shouldExecuteEachBinaryOperatorInOrder() {
+        // Given
+        BinaryOperatorComposite instance = getInstance(); // Sum then Product
+        BinaryOperatorComposite reversed = new BinaryOperatorComposite(Arrays.asList(
+                new Product(),
+                new Sum()
+        ));
+
+        // When
+        Object aggregated = instance.apply(5, 10);
+        Object aggregatedInReverseOrder = reversed.apply(5, 10);
+
+        // Then
+        assertEquals(150, aggregated); // (5 + 10) x 10 = 150
+        assertEquals(60, aggregatedInReverseOrder); // (5 x 10) + 10 = 60
+
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/binaryoperator/BinaryOperatorTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/binaryoperator/BinaryOperatorTest.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.koryphe.binaryoperator;
 
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.koryphe.util.EqualityTest;
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
@@ -27,16 +28,15 @@ import uk.gov.gchq.koryphe.util.VersionUtil;
 import java.io.IOException;
 import java.util.function.BinaryOperator;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public abstract class BinaryOperatorTest {
+public abstract class BinaryOperatorTest<T extends BinaryOperator> extends EqualityTest<T> {
 
-    protected abstract BinaryOperator getInstance();
-
-    protected abstract Class<? extends BinaryOperator> getFunctionClass();
+    protected Class<? extends BinaryOperator> getFunctionClass() {
+        return getInstance().getClass();
+    }
 
     @Test
     public abstract void shouldJsonSerialiseAndDeserialise() throws IOException;
@@ -50,45 +50,9 @@ public abstract class BinaryOperatorTest {
     }
 
     @Test
-    public void shouldEquals() {
-        // Given
-        final BinaryOperator instance = getInstance();
-
-        // When
-        final BinaryOperator other = getInstance();
-
-        // Then
-        assertEquals(instance, other);
-        assertEquals(instance.hashCode(), other.hashCode());
-    }
-
-    @Test
-    public void shouldEqualsWhenSameObject() {
-        // Given
-        final BinaryOperator instance = getInstance();
-
-        // Then
-        assertEquals(instance, instance);
-        assertEquals(instance.hashCode(), instance.hashCode());
-    }
-
-    @Test
-    public void shouldNotEqualsWhenDifferentClass() {
-        // Given
-        final BinaryOperator instance = getInstance();
-
-        // When
-        final Object other = new Object();
-
-        // Then
-        assertNotEquals(instance, other);
-        assertNotEquals(instance.hashCode(), other.hashCode());
-    }
-
-    @Test
     public void shouldNotEqualsNull() {
         // Given
-        final BinaryOperator instance = getInstance();
+        final T instance = getInstance();
 
         // Then
         assertNotEquals(instance, null);
@@ -97,7 +61,7 @@ public abstract class BinaryOperatorTest {
     @Test
     public void shouldHaveSinceAnnotation() {
         // Given
-        final BinaryOperator instance = getInstance();
+        final T instance = getInstance();
 
         // When
         final Since annotation = instance.getClass().getAnnotation(Since.class);
@@ -112,7 +76,7 @@ public abstract class BinaryOperatorTest {
     @Test
     public void shouldHaveSummaryAnnotation() {
         // Given
-        final BinaryOperator instance = getInstance();
+        final T instance = getInstance();
 
         // When
         final Summary annotation = instance.getClass().getAnnotation(Summary.class);

--- a/core/src/test/java/uk/gov/gchq/koryphe/function/FunctionCompositeTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/function/FunctionCompositeTest.java
@@ -1,0 +1,122 @@
+package uk.gov.gchq.koryphe.function;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.impl.function.MultiplyLongBy;
+import uk.gov.gchq.koryphe.impl.function.StringSplit;
+import uk.gov.gchq.koryphe.impl.function.ToLong;
+import uk.gov.gchq.koryphe.impl.function.ToString;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FunctionCompositeTest extends FunctionTest<FunctionComposite>{
+    @Override
+    protected Class[] getExpectedSignatureInputClasses() {
+        return new Class[] { Object.class };
+    }
+
+    @Override
+    protected Class[] getExpectedSignatureOutputClasses() {
+        return new Class[] { Object.class };
+    }
+
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        FunctionComposite functionComposite = getInstance();
+        String json =
+                "{" +
+                    "\"functions\": [" +
+                        "{" +
+                            "\"class\": \"uk.gov.gchq.koryphe.impl.function.ToLong\"" +
+                        "}," +
+                        "{" +
+                            "\"class\": \"uk.gov.gchq.koryphe.impl.function.MultiplyLongBy\"," +
+                            "\"by\": 10" +
+                        "}" +
+                    "]" +
+                "}";
+
+        // When
+        String serialised = JsonSerialiser.serialise(functionComposite);
+        FunctionComposite deserialised = JsonSerialiser.deserialise(json, FunctionComposite.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(functionComposite, deserialised);
+    }
+
+    @Override
+    protected FunctionComposite getInstance() {
+        return new FunctionComposite(Arrays.asList(
+                new ToLong(),
+                new MultiplyLongBy(10L)
+        ));
+    }
+
+    @Override
+    protected Iterable<FunctionComposite> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new FunctionComposite(),
+                new FunctionComposite(Arrays.asList(
+                        new ToString(),
+                        new StringSplit(",")
+                )),
+                new FunctionComposite(Arrays.asList(
+                        new ToLong(),
+                        new MultiplyLongBy(100L)
+                ))
+        );
+    }
+
+    @Test
+    public void shouldReturnInputIfNoComponentsAreProvided() {
+        // Given
+        FunctionComposite<String, String, Function> functionComposite = new FunctionComposite<>();
+
+        // When
+        String output = functionComposite.apply("test");
+
+        // Then
+        assertEquals("test", output);
+    }
+
+    @Test
+    public void shouldApplyFunctionsInOrder() {
+        // Given
+        FunctionComposite<String, Long, Function> functionComposite = new FunctionComposite<>(Arrays.asList(
+                new ToLong(),
+                new MultiplyLongBy(100L)
+        ));
+
+        // When
+        Long transformed = functionComposite.apply("4");
+
+        // Then
+        assertEquals(400L, transformed);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfInputsAndOutputsDontMatch() {
+        // Given
+        FunctionComposite<Integer, Long, Function> functionComposite = new FunctionComposite<>(Arrays.asList(
+                new ToLong(),
+                new StringSplit(" ")
+        ));
+
+        // When / Then
+        ClassCastException e = assertThrows(ClassCastException.class, () -> {
+            functionComposite.apply(5);
+        });
+
+        assertNotNull(e.getMessage());
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/function/FunctionTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/function/FunctionTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.koryphe.util.EqualityTest;
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.signature.Signature;
@@ -29,13 +30,11 @@ import uk.gov.gchq.koryphe.util.VersionUtil;
 import java.io.IOException;
 import java.util.function.Function;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public abstract class FunctionTest {
+public abstract class FunctionTest<T extends Function> extends EqualityTest<T> {
 
     private static final ObjectMapper MAPPER = createObjectMapper();
 
@@ -46,15 +45,14 @@ public abstract class FunctionTest {
         return mapper;
     }
 
-    protected abstract Function getInstance();
-
-    protected abstract Class<? extends Function> getFunctionClass();
+    protected Class<? extends Function> getFunctionClass() {
+        return getInstance().getClass();
+    }
 
     protected abstract Class[] getExpectedSignatureInputClasses();
 
     protected abstract Class[] getExpectedSignatureOutputClasses();
 
-    @Test
     public abstract void shouldJsonSerialiseAndDeserialise() throws IOException;
 
     protected String serialise(Object object) throws IOException {
@@ -63,51 +61,6 @@ public abstract class FunctionTest {
 
     protected Function deserialise(String json) throws IOException {
         return MAPPER.readValue(json, getFunctionClass());
-    }
-
-    @Test
-    public void shouldEquals() {
-        // Given
-        final Function instance = getInstance();
-
-        // When
-        final Function other = getInstance();
-
-        // Then
-        assertEquals(instance, other);
-        assertEquals(instance.hashCode(), other.hashCode());
-    }
-
-    @Test
-    public void shouldEqualsWhenSameObject() {
-        // Given
-        final Function instance = getInstance();
-
-        // Then
-        assertEquals(instance, instance);
-        assertEquals(instance.hashCode(), instance.hashCode());
-    }
-
-    @Test
-    public void shouldNotEqualsWhenDifferentClass() {
-        // Given
-        final Function instance = getInstance();
-
-        // When
-        final Object other = new Object();
-
-        // Then
-        assertNotEquals(instance, other);
-        assertNotEquals(instance.hashCode(), other.hashCode());
-    }
-
-    @Test
-    public void shouldNotEqualsNull() {
-        // Given
-        final Function instance = getInstance();
-
-        // Then
-        assertNotNull(instance);
     }
 
     @Test

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/AndTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/AndTest.java
@@ -21,13 +21,12 @@ import uk.gov.gchq.koryphe.binaryoperator.BinaryOperatorTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
-import java.util.function.BinaryOperator;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AndTest extends BinaryOperatorTest {
+public class AndTest extends BinaryOperatorTest<And> {
 
     @Test
     public void shouldCompareBooleans() {
@@ -62,15 +61,16 @@ public class AndTest extends BinaryOperatorTest {
     }
 
     @Override
-    protected BinaryOperator getInstance() {
+    protected And getInstance() {
         return new And();
     }
 
     @Override
-    protected Class<? extends BinaryOperator> getFunctionClass() {
-        return And.class;
+    protected Iterable<And> getDifferentInstancesOrNull() {
+        return null;
     }
 
+    @Test
     @Override
     public void shouldJsonSerialiseAndDeserialise() throws IOException {
         // Given

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/CollectionConcatTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/CollectionConcatTest.java
@@ -15,7 +15,7 @@ import java.util.TreeSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class CollectionConcatTest extends BinaryOperatorTest {
+public class CollectionConcatTest extends BinaryOperatorTest<CollectionConcat> {
 
     @Test
     public void shouldConcatArraysTogether() {
@@ -95,7 +95,7 @@ public class CollectionConcatTest extends BinaryOperatorTest {
                 "}"), json);
 
         // When 2
-        final CollectionConcat deserialisedAggregator = JsonSerialiser.deserialise(json, getFunctionClass());
+        final CollectionConcat deserialisedAggregator = JsonSerialiser.deserialise(json, CollectionConcat.class);
 
         // Then 2
         assertNotNull(deserialisedAggregator);
@@ -107,7 +107,7 @@ public class CollectionConcatTest extends BinaryOperatorTest {
     }
 
     @Override
-    protected Class<CollectionConcat> getFunctionClass() {
-        return CollectionConcat.class;
+    protected Iterable<CollectionConcat> getDifferentInstancesOrNull() {
+        return null;
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/CollectionIntersectTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/CollectionIntersectTest.java
@@ -32,7 +32,7 @@ import java.util.TreeSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class CollectionIntersectTest extends BinaryOperatorTest {
+public class CollectionIntersectTest extends BinaryOperatorTest<CollectionIntersect> {
 
     @Test
     public void shouldIntersectArraysTogether() {
@@ -124,7 +124,7 @@ public class CollectionIntersectTest extends BinaryOperatorTest {
                 "}"), json);
 
         // When 2
-        final CollectionIntersect deserialisedAggregator = JsonSerialiser.deserialise(json, getFunctionClass());
+        final CollectionIntersect deserialisedAggregator = JsonSerialiser.deserialise(json, CollectionIntersect.class);
 
         // Then 2
         assertNotNull(deserialisedAggregator);
@@ -136,7 +136,8 @@ public class CollectionIntersectTest extends BinaryOperatorTest {
     }
 
     @Override
-    protected Class<CollectionIntersect> getFunctionClass() {
-        return CollectionIntersect.class;
+    protected Iterable<CollectionIntersect> getDifferentInstancesOrNull() {
+        return null;
     }
+
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/MaxTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/MaxTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MaxTest extends BinaryOperatorTest {
+public class MaxTest extends BinaryOperatorTest<Max> {
 
     @Test
     public void testAggregateInIntMode() {
@@ -156,7 +156,7 @@ public class MaxTest extends BinaryOperatorTest {
     }
 
     @Override
-    protected Class<Max> getFunctionClass() {
-        return Max.class;
+    protected Iterable<Max> getDifferentInstancesOrNull() {
+        return null;
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/MinTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/MinTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MinTest extends BinaryOperatorTest {
+public class MinTest extends BinaryOperatorTest<Min> {
 
     @Test
     public void testAggregateInIntMode() {
@@ -156,7 +156,8 @@ public class MinTest extends BinaryOperatorTest {
     }
 
     @Override
-    protected Class<Min> getFunctionClass() {
-        return Min.class;
+    protected Iterable<Min> getDifferentInstancesOrNull() {
+        return null;
     }
+
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/OrTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/OrTest.java
@@ -22,13 +22,12 @@ import uk.gov.gchq.koryphe.binaryoperator.BinaryOperatorTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
-import java.util.function.BinaryOperator;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class OrTest extends BinaryOperatorTest {
+public class OrTest extends BinaryOperatorTest<Or> {
 
     @Test
     public void shouldCompareBooleans() {
@@ -63,13 +62,13 @@ public class OrTest extends BinaryOperatorTest {
     }
 
     @Override
-    protected BinaryOperator getInstance() {
+    protected Or getInstance() {
         return new Or();
     }
 
     @Override
-    protected Class<? extends BinaryOperator> getFunctionClass() {
-        return Or.class;
+    protected Iterable<Or> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Test

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/ProductTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/ProductTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ProductTest extends BinaryOperatorTest {
+public class ProductTest extends BinaryOperatorTest<Product> {
 
     @Test
     public void testAggregateInShortMode() {
@@ -360,7 +360,7 @@ public class ProductTest extends BinaryOperatorTest {
     }
 
     @Override
-    protected Class<Product> getFunctionClass() {
-        return Product.class;
+    protected Iterable<Product> getDifferentInstancesOrNull() {
+        return null;
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/StringConcatTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/StringConcatTest.java
@@ -7,11 +7,12 @@ import uk.gov.gchq.koryphe.binaryoperator.BinaryOperatorTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class StringConcatTest extends BinaryOperatorTest {
+public class StringConcatTest extends BinaryOperatorTest<StringConcat> {
 
     private String state;
 
@@ -50,7 +51,7 @@ public class StringConcatTest extends BinaryOperatorTest {
                 "}"), json);
 
         // When 2
-        final StringConcat deserialisedAggregator = JsonSerialiser.deserialise(json, getFunctionClass());
+        final StringConcat deserialisedAggregator = JsonSerialiser.deserialise(json, StringConcat.class);
 
         // Then 2
         assertNotNull(deserialisedAggregator);
@@ -62,7 +63,10 @@ public class StringConcatTest extends BinaryOperatorTest {
     }
 
     @Override
-    protected Class<StringConcat> getFunctionClass() {
-        return StringConcat.class;
+    protected Iterable<StringConcat> getDifferentInstancesOrNull() {
+        StringConcat alternative = new StringConcat();
+        alternative.setSeparator(" ");
+        return Collections.singletonList(alternative);
     }
+
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/StringDeduplicateConcatTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/StringDeduplicateConcatTest.java
@@ -21,11 +21,12 @@ import uk.gov.gchq.koryphe.binaryoperator.BinaryOperatorTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class StringDeduplicateConcatTest extends BinaryOperatorTest {
+public class StringDeduplicateConcatTest extends BinaryOperatorTest<StringDeduplicateConcat> {
 
     @Test
     public void shouldRemoveDuplicate() {
@@ -106,8 +107,10 @@ public class StringDeduplicateConcatTest extends BinaryOperatorTest {
     }
 
     @Override
-    protected Class<StringDeduplicateConcat> getFunctionClass() {
-        return StringDeduplicateConcat.class;
+    protected Iterable<StringDeduplicateConcat> getDifferentInstancesOrNull() {
+        StringDeduplicateConcat stringDeduplicateConcat = new StringDeduplicateConcat();
+        stringDeduplicateConcat.setSeparator("test");
+        return Collections.singletonList(stringDeduplicateConcat);
     }
 
     @Test
@@ -127,7 +130,7 @@ public class StringDeduplicateConcatTest extends BinaryOperatorTest {
 
         // When 2
         final StringDeduplicateConcat deserialisedOperator =
-                JsonSerialiser.deserialise(json, getFunctionClass());
+                JsonSerialiser.deserialise(json, StringDeduplicateConcat.class);
 
         // Then 2
         assertEquals(";", deserialisedOperator.getSeparator());

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/SumTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/binaryoperator/SumTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SumTest extends BinaryOperatorTest {
+public class SumTest extends BinaryOperatorTest<Sum> {
 
     @Test
     public void testAggregateShorts() {
@@ -434,7 +434,7 @@ public class SumTest extends BinaryOperatorTest {
     }
 
     @Override
-    protected Class<Sum> getFunctionClass() {
-        return Sum.class;
+    protected Iterable<Sum> getDifferentInstancesOrNull() {
+        return null;
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ApplyBiFunctionTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ApplyBiFunctionTest.java
@@ -18,25 +18,26 @@ package uk.gov.gchq.koryphe.impl.function;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.impl.binaryoperator.And;
 import uk.gov.gchq.koryphe.impl.binaryoperator.Sum;
 import uk.gov.gchq.koryphe.tuple.n.Tuple2;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
-import java.util.function.Function;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ApplyBiFunctionTest extends FunctionTest {
+public class ApplyBiFunctionTest extends FunctionTest<ApplyBiFunction> {
     @Override
-    protected Function getInstance() {
+    protected ApplyBiFunction getInstance() {
         return new ApplyBiFunction(new Sum());
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ApplyBiFunction.class;
+    protected Iterable<ApplyBiFunction> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new ApplyBiFunction(new And()));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/Base64DecodeTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/Base64DecodeTest.java
@@ -23,21 +23,20 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class Base64DecodeTest extends FunctionTest {
+public class Base64DecodeTest extends FunctionTest<Base64Decode> {
     @Override
-    protected Function getInstance() {
+    protected Base64Decode getInstance() {
         return new Base64Decode();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return Base64Decode.class;
+    protected Iterable<Base64Decode> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CallMethodTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CallMethodTest.java
@@ -23,16 +23,16 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class CallMethodTest extends FunctionTest {
+public class CallMethodTest extends FunctionTest<CallMethod> {
 
     private static final String TEST_METHOD = "testMethod";
 
@@ -99,13 +99,13 @@ public class CallMethodTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected CallMethod getInstance() {
         return new CallMethod();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return CallMethod.class;
+    protected Iterable<CallMethod> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new CallMethod("toString"));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CastTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CastTest.java
@@ -23,12 +23,12 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
-import java.util.function.Function;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class CastTest extends FunctionTest {
+public class CastTest extends FunctionTest<Cast> {
 
     @Disabled
     @Test
@@ -44,13 +44,13 @@ public class CastTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected Cast getInstance() {
         return new Cast<>();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return Cast.class;
+    protected Iterable<Cast> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new Cast<>(Integer.class));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ConcatTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ConcatTest.java
@@ -22,12 +22,13 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ConcatTest extends FunctionTest {
+public class ConcatTest extends FunctionTest<Concat> {
 
     @Test
     public void shouldConcatStringsWithDefaultSeparator() {
@@ -80,6 +81,12 @@ public class ConcatTest extends FunctionTest {
     }
 
     @Override
+    protected Iterable<Concat> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new Concat(" "));
+    }
+
+    @Test
+    @Override
     public void shouldJsonSerialiseAndDeserialise() throws IOException {
         // Given
         final String separator = "-";
@@ -101,11 +108,6 @@ public class ConcatTest extends FunctionTest {
         // Then 2
         assertNotNull(deserialisedConcat);
         assertEquals(separator, deserialisedConcat.getSeparator());
-    }
-
-    @Override
-    protected Class<Concat> getFunctionClass() {
-        return Concat.class;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CreateObjectTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CreateObjectTest.java
@@ -24,17 +24,17 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CreateObjectTest extends FunctionTest {
+public class CreateObjectTest extends FunctionTest<CreateObject> {
 
     @Test
     public void shouldCreateNewObjectUsingNoArgConstructor() {
@@ -87,6 +87,7 @@ public class CreateObjectTest extends FunctionTest {
         assertEquals(expected, exception.getMessage());
     }
 
+    @Test
     @Override
     public void shouldJsonSerialiseAndDeserialise() throws IOException {
         // Given
@@ -110,13 +111,13 @@ public class CreateObjectTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected CreateObject getInstance() {
         return new CreateObject();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return CreateObject.class;
+    protected Iterable<CreateObject> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new CreateObject(Integer.class));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CsvLinesToMapsTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CsvLinesToMapsTest.java
@@ -27,20 +27,25 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class CsvLinesToMapsTest extends FunctionTest {
+public class CsvLinesToMapsTest extends FunctionTest<CsvLinesToMaps> {
     @Override
-    protected Function getInstance() {
+    protected CsvLinesToMaps getInstance() {
         return new CsvLinesToMaps();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return CsvLinesToMaps.class;
+    protected Iterable<CsvLinesToMaps> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new CsvLinesToMaps().delimiter('\t'),
+                new CsvLinesToMaps().firstRow(8),
+                new CsvLinesToMaps().quoteChar('\''),
+                new CsvLinesToMaps().quoted(),
+                new CsvLinesToMaps().header("myHeader")
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CsvToMapsTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CsvToMapsTest.java
@@ -22,23 +22,29 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class CsvToMapsTest extends FunctionTest {
+public class CsvToMapsTest extends FunctionTest<CsvToMaps> {
     @Override
-    protected Function getInstance() {
+    protected CsvToMaps getInstance() {
         return new CsvToMaps();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return CsvToMaps.class;
+    protected Iterable<CsvToMaps> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new CsvToMaps().delimiter('\t'),
+                new CsvToMaps().firstRow(8),
+                new CsvToMaps().quoteChar('\''),
+                new CsvToMaps().quoted(),
+                new CsvToMaps().header("myHeader")
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CurrentDateTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CurrentDateTest.java
@@ -1,0 +1,51 @@
+package uk.gov.gchq.koryphe.impl.function;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CurrentDateTest extends FunctionTest<CurrentDate> {
+
+    @Override
+    protected Class[] getExpectedSignatureInputClasses() {
+        return new Class[] { Object.class };
+    }
+
+    @Override
+    protected Class[] getExpectedSignatureOutputClasses() {
+        return new Class[] { Date.class };
+    }
+
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        String json = "{ \"class\": \"uk.gov.gchq.koryphe.impl.function.CurrentDate\" }";
+        CurrentDate CurrentDate = new CurrentDate();
+
+        // When
+        String serialised = JsonSerialiser.serialise(CurrentDate);
+        CurrentDate deserialised = JsonSerialiser.deserialise(json, CurrentDate.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(CurrentDate, deserialised);
+
+    }
+
+    @Override
+    protected CurrentDate getInstance() {
+        return new CurrentDate();
+    }
+
+    @Override
+    protected Iterable<CurrentDate> getDifferentInstancesOrNull() {
+        return null;
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CurrentTimeTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/CurrentTimeTest.java
@@ -1,0 +1,50 @@
+package uk.gov.gchq.koryphe.impl.function;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CurrentTimeTest extends FunctionTest<CurrentTime> {
+
+    @Override
+    protected Class[] getExpectedSignatureInputClasses() {
+        return new Class[] { Object.class };
+    }
+
+    @Override
+    protected Class[] getExpectedSignatureOutputClasses() {
+        return new Class[] { Long.class };
+    }
+
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        String json = "{ \"class\": \"uk.gov.gchq.koryphe.impl.function.CurrentTime\" }";
+        CurrentTime currentTime = new CurrentTime();
+
+        // When
+        String serialised = JsonSerialiser.serialise(currentTime);
+        CurrentTime deserialised = JsonSerialiser.deserialise(json, CurrentTime.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(currentTime, deserialised);
+
+    }
+
+    @Override
+    protected CurrentTime getInstance() {
+        return new CurrentTime();
+    }
+
+    @Override
+    protected Iterable<CurrentTime> getDifferentInstancesOrNull() {
+        return null;
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DefaultIfEmptyTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DefaultIfEmptyTest.java
@@ -24,24 +24,23 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class DefaultIfEmptyTest extends FunctionTest {
+public class DefaultIfEmptyTest extends FunctionTest<DefaultIfEmpty> {
 
     private final static String DEFAULT_VALUE = "default";
 
     @Override
-    protected Function getInstance() {
+    protected DefaultIfEmpty getInstance() {
         return new DefaultIfEmpty();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return DefaultIfEmpty.class;
+    protected Iterable<DefaultIfEmpty> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new DefaultIfEmpty("Default"));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DefaultIfNullTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DefaultIfNullTest.java
@@ -21,23 +21,23 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
-import java.util.function.Function;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class DefaultIfNullTest extends FunctionTest {
+public class DefaultIfNullTest extends FunctionTest<DefaultIfNull> {
 
     private final static String DEFAULT_VALUE = "default";
 
     @Override
-    protected Function getInstance() {
+    protected DefaultIfNull getInstance() {
         return new DefaultIfNull();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return DefaultIfNull.class;
+    protected Iterable<DefaultIfNull> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new DefaultIfNull(42L));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DeserialiseJsonTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DeserialiseJsonTest.java
@@ -22,22 +22,22 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class DeserialiseJsonTest extends FunctionTest {
+public class DeserialiseJsonTest extends FunctionTest<DeserialiseJson> {
     @Override
-    protected Function getInstance() {
+    protected DeserialiseJson getInstance() {
         return new DeserialiseJson();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return DeserialiseJson.class;
+    protected Iterable<DeserialiseJson> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new DeserialiseJson(Long.class));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DeserialiseXmlTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DeserialiseXmlTest.java
@@ -24,20 +24,19 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class DeserialiseXmlTest extends FunctionTest {
+public class DeserialiseXmlTest extends FunctionTest<DeserialiseXml> {
     @Override
-    protected Function getInstance() {
+    protected DeserialiseXml getInstance() {
         return new DeserialiseXml();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return DeserialiseXml.class;
+    protected Iterable<DeserialiseXml> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DictionaryLookupTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DictionaryLookupTest.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import com.google.common.collect.Maps;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,16 +24,16 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class DictionaryLookupTest extends FunctionTest {
+public class DictionaryLookupTest extends FunctionTest<DictionaryLookup<?, ?>> {
 
     private Map<String, Integer> dictionary = new HashMap<>();
     ;
@@ -70,13 +71,20 @@ public class DictionaryLookupTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
-        return new DictionaryLookup();
+    protected DictionaryLookup<String, Integer> getInstance() {
+        HashMap<String, Integer> map = new HashMap<>();
+        map.put("one", 1);
+        map.put("two", 2);
+
+        return new DictionaryLookup(map);
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return DictionaryLookup.class;
+    protected Iterable<DictionaryLookup<?, ?>> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new DictionaryLookup<>(null),
+                new DictionaryLookup<>(Maps.newHashMap())
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DivideByTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DivideByTest.java
@@ -23,11 +23,12 @@ import uk.gov.gchq.koryphe.tuple.n.Tuple2;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class DivideByTest extends FunctionTest {
+public class DivideByTest extends FunctionTest<DivideBy> {
 
     @Test
     public void shouldDivideBy2() {
@@ -91,8 +92,8 @@ public class DivideByTest extends FunctionTest {
     }
 
     @Override
-    protected Class<DivideBy> getFunctionClass() {
-        return DivideBy.class;
+    protected Iterable<DivideBy> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new DivideBy(5));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DivideTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/DivideTest.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class DivideTest extends FunctionTest {
+public class DivideTest extends FunctionTest<Divide> {
 
     @Test
     public void shouldDivide2() {
@@ -62,6 +62,7 @@ public class DivideTest extends FunctionTest {
         assertEquals(new Tuple2<>(9, 0), output);
     }
 
+    @Test
     @Override
     public void shouldJsonSerialiseAndDeserialise() throws IOException {
         // Given
@@ -88,8 +89,8 @@ public class DivideTest extends FunctionTest {
     }
 
     @Override
-    protected Class<Divide> getFunctionClass() {
-        return Divide.class;
+    protected Iterable getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ExtractKeysTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ExtractKeysTest.java
@@ -25,22 +25,21 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ExtractKeysTest extends FunctionTest {
+public class ExtractKeysTest extends FunctionTest<ExtractKeys> {
     @Override
-    protected Function getInstance() {
+    protected ExtractKeys getInstance() {
         return new ExtractKeys();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ExtractKeys.class;
+    protected Iterable<ExtractKeys> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ExtractValueTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ExtractValueTest.java
@@ -21,23 +21,23 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ExtractValueTest extends FunctionTest {
+public class ExtractValueTest extends FunctionTest<ExtractValue> {
     @Override
-    protected Function getInstance() {
+    protected ExtractValue<String, Integer> getInstance() {
         return new ExtractValue<String, Integer>("testKey");
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ExtractValue.class;
+    protected Iterable<ExtractValue> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new ExtractValue("differentKey"));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ExtractValuesTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ExtractValuesTest.java
@@ -24,7 +24,6 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -32,15 +31,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ExtractValuesTest extends FunctionTest {
+public class ExtractValuesTest extends FunctionTest<ExtractValues> {
     @Override
-    protected Function getInstance() {
+    protected ExtractValues getInstance() {
         return new ExtractValues();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ExtractValues.class;
+    protected Iterable<ExtractValues> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/FirstItemTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/FirstItemTest.java
@@ -22,7 +22,6 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -30,25 +29,25 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class FirstItemTest extends FunctionTest {
+public class FirstItemTest extends FunctionTest<FirstItem> {
     @Override
-    protected Function getInstance() {
+    protected FirstItem getInstance() {
         return new FirstItem();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return FirstItem.class;
+    protected Iterable<FirstItem> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override
     protected Class[] getExpectedSignatureInputClasses() {
-        return new Class[] {Iterable.class};
+        return new Class[]{Iterable.class};
     }
 
     @Override
     protected Class[] getExpectedSignatureOutputClasses() {
-        return new Class[] {Object.class};
+        return new Class[]{Object.class};
     }
 
     @Test

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/FirstValidTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/FirstValidTest.java
@@ -18,19 +18,19 @@ package uk.gov.gchq.koryphe.impl.function;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.impl.predicate.IsLessThan;
 import uk.gov.gchq.koryphe.impl.predicate.IsMoreThan;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class FirstValidTest extends FunctionTest {
+public class FirstValidTest extends FunctionTest<FirstValid> {
 
     @Test
     public void shouldApplyKeyPredicate() {
@@ -84,8 +84,11 @@ public class FirstValidTest extends FunctionTest {
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return FirstValid.class;
+    protected Iterable<FirstValid> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new FirstValid<>(new IsMoreThan(4)),
+                new FirstValid<>(new IsLessThan(3))
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/FunctionChainTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/FunctionChainTest.java
@@ -23,19 +23,28 @@ import uk.gov.gchq.koryphe.tuple.ArrayTuple;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
-import java.util.function.Function;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class FunctionChainTest extends FunctionTest {
+public class FunctionChainTest extends FunctionTest<FunctionChain> {
     @Override
-    protected Function getInstance() {
-        return new FunctionChain();
+    protected FunctionChain getInstance() {
+        return new FunctionChain.Builder<>()
+                .execute(new ToInteger())
+                .execute(new DivideBy(3))
+                .build();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return FunctionChain.class;
+    protected Iterable<FunctionChain> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new FunctionChain<>(),
+                new FunctionChain.Builder<>()
+                        .execute(new ToString())
+                        .execute(new StringSplit())
+                .build()
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/GunzipTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/GunzipTest.java
@@ -23,33 +23,32 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.function.Function;
 import java.util.zip.GZIPOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class GunzipTest extends FunctionTest {
+public class GunzipTest extends FunctionTest<Gunzip> {
 
     @Override
-    protected Function getInstance() {
+    protected Gunzip getInstance() {
         return new Gunzip();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return Gunzip.class;
+    protected Iterable<Gunzip> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override
     protected Class[] getExpectedSignatureInputClasses() {
-        return new Class[] { byte[].class };
+        return new Class[]{byte[].class};
     }
 
     @Override
     protected Class[] getExpectedSignatureOutputClasses() {
-        return new Class[] { byte[].class };
+        return new Class[]{byte[].class};
     }
 
     @Test

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IfTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IfTest.java
@@ -27,6 +27,7 @@ import uk.gov.gchq.koryphe.tuple.function.KorypheFunction2;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -40,7 +41,7 @@ import static org.mockito.Mockito.verify;
 import static uk.gov.gchq.koryphe.util.Util.project;
 import static uk.gov.gchq.koryphe.util.Util.select;
 
-public class IfTest extends FunctionTest {
+public class IfTest extends FunctionTest<If> {
 
     @Override
     protected If<Object, Object> getInstance() {
@@ -50,16 +51,30 @@ public class IfTest extends FunctionTest {
                 .otherwise(new SetValue("value2"));
     }
 
+    @Override
+    protected Iterable<If> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new If<>()
+                        .condition(false)
+                        .then(new SetValue("value1"))
+                        .otherwise(new SetValue("value2")),
+                new If<>()
+                        .condition(true)
+                        .then(new SetValue("differentThenValue"))
+                        .otherwise(new SetValue("value2")),
+                new If<>()
+                        .condition(true)
+                        .then(new SetValue("value1"))
+                        .otherwise(new SetValue("differentOtherwiseValue")),
+                getAltInstance()
+        );
+    }
+
     private If<Comparable, Comparable> getAltInstance() {
         return new If<Comparable, Comparable>()
                 .predicate(new IsA(Integer.class))
                 .then(new SetValue("value2"))
                 .otherwise(new SetValue("value3"));
-    }
-
-    @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return If.class;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IncrementTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IncrementTest.java
@@ -1,0 +1,112 @@
+package uk.gov.gchq.koryphe.impl.function;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IncrementTest extends FunctionTest<Increment> {
+    @Override
+    protected Class[] getExpectedSignatureInputClasses() {
+        return new Class[] { Number.class };
+    }
+
+    @Override
+    protected Class[] getExpectedSignatureOutputClasses() {
+        return new Class[] { Number.class };
+    }
+
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        String json = "{ \"class\": \"uk.gov.gchq.koryphe.impl.function.Increment\" }";
+        Increment increment = new Increment();
+
+        // When
+        String serialised = JsonSerialiser.serialise(increment);
+        Increment deserialised = JsonSerialiser.deserialise(json, Increment.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(increment, deserialised);
+    }
+
+    @Test
+    public void shouldReturnIncrementIfInputIsNull() {
+        // Given
+        Increment increment = new Increment(5);
+
+        // When
+        Number value = increment.apply(null);
+
+        // Then
+        assertEquals(5, value);
+    }
+
+    @Test
+    public void shouldReturnInputIfIncrementIsNull() {
+        // Given
+        Increment increment = new Increment();
+
+        // When
+        Number output = increment.apply(8);
+
+        // Then
+        assertEquals(8, output);
+    }
+
+    @Test
+    public void shouldMatchOutputTypeWithIncrementType() {
+        // Given
+        Increment increment = new Increment(10L);
+
+        // When
+        Number output = increment.apply(2);
+
+        // Then
+        assertEquals(Long.class, output.getClass());
+    }
+
+    @Test
+    public void shouldIncrementByTheSetIncrement() {
+        // Given
+        Increment increment = new Increment(10L);
+
+        // When
+        Number output = increment.apply(2);
+
+        // Then
+        assertEquals(12, output.intValue());
+    }
+
+    @Test
+    public void shouldBeAbleToHandleDifferentInputAndIncrementTypes() {
+        // Given
+        Increment increment = new Increment(10.5);
+
+        // When
+        Number output = increment.apply(2);
+
+        // Then
+        assertEquals(12.5, output);
+    }
+
+    @Override
+    protected Increment getInstance() {
+        return new Increment(3);
+    }
+
+    @Override
+    protected Iterable<Increment> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new Increment(3L),
+                new Increment(5),
+                new Increment());
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IsEmptyTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IsEmptyTest.java
@@ -23,7 +23,6 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,15 +30,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IsEmptyTest extends FunctionTest {
+public class IsEmptyTest extends FunctionTest<IsEmpty> {
     @Override
-    protected Function getInstance() {
+    protected IsEmpty getInstance() {
         return new IsEmpty();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return IsEmpty.class;
+    protected Iterable<IsEmpty> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableConcatTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableConcatTest.java
@@ -25,22 +25,21 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IterableConcatTest extends FunctionTest {
+public class IterableConcatTest extends FunctionTest<IterableConcat> {
     @Override
-    protected Function getInstance() {
+    protected IterableConcat getInstance() {
         return new IterableConcat();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return IterableConcat.class;
+    protected Iterable<IterableConcat> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableFilterTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableFilterTest.java
@@ -19,20 +19,20 @@ import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.impl.predicate.IsLessThan;
 import uk.gov.gchq.koryphe.impl.predicate.IsMoreThan;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class IterableFilterTest extends FunctionTest {
+public class IterableFilterTest extends FunctionTest<IterableFilter> {
 
     @Test
     public void shouldApplyKeyPredicate() {
@@ -89,8 +89,11 @@ public class IterableFilterTest extends FunctionTest {
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return IterableFilter.class;
+    protected Iterable<IterableFilter> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new IterableFilter(),
+                new IterableFilter(new IsLessThan(4L))
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableFlattenTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableFlattenTest.java
@@ -20,10 +20,12 @@ import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.impl.binaryoperator.StringConcat;
 import uk.gov.gchq.koryphe.impl.binaryoperator.Sum;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -31,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class IterableFlattenTest extends FunctionTest {
+public class IterableFlattenTest extends FunctionTest<IterableFlatten> {
 
     @Test
     public void shouldHandleNullInput() {
@@ -77,8 +79,8 @@ public class IterableFlattenTest extends FunctionTest {
     }
 
     @Override
-    protected Class<? extends IterableFlatten> getFunctionClass() {
-        return IterableFlatten.class;
+    protected Iterable<IterableFlatten> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new IterableFlatten(new StringConcat()));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableFunctionTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableFunctionTest.java
@@ -25,6 +25,7 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
@@ -34,15 +35,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IterableFunctionTest extends FunctionTest {
+public class IterableFunctionTest extends FunctionTest<IterableFunction> {
     @Override
-    protected Function getInstance() {
+    protected IterableFunction getInstance() {
         return new IterableFunction();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return IterableFunction.class;
+    protected Iterable<IterableFunction> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new IterableFunction(new ToLong()));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableLongestTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableLongestTest.java
@@ -8,13 +8,12 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class IterableLongestTest extends FunctionTest {
+public class IterableLongestTest extends FunctionTest<IterableLongest> {
 
     @Test
     public void shouldHandleNullInput() {
@@ -47,8 +46,8 @@ public class IterableLongestTest extends FunctionTest {
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return IterableLongest.class;
+    protected Iterable<IterableLongest> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/LastItemTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/LastItemTest.java
@@ -22,22 +22,21 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class LastItemTest extends FunctionTest {
+public class LastItemTest extends FunctionTest<LastItem> {
     @Override
-    protected Function getInstance() {
+    protected LastItem getInstance() {
         return new LastItem();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return LastItem.class;
+    protected Iterable<LastItem> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/LengthTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/LengthTest.java
@@ -23,12 +23,12 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -36,15 +36,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LengthTest extends FunctionTest {
+public class LengthTest extends FunctionTest<Length> {
     @Override
-    protected Function getInstance() {
+    protected Length getInstance() {
         return new Length();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return Length.class;
+    protected Iterable<Length> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new Length(5));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/LongestTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/LongestTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class LongestTest extends FunctionTest {
+public class LongestTest extends FunctionTest<Longest> {
 
     @Test
     public void shouldHandleNullInputs() {
@@ -122,8 +122,8 @@ public class LongestTest extends FunctionTest {
     }
 
     @Override
-    protected Class<? extends Longest> getFunctionClass() {
-        return Longest.class;
+    protected Iterable<Longest> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/MapFilterTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/MapFilterTest.java
@@ -23,10 +23,12 @@ import uk.gov.gchq.koryphe.impl.predicate.IsA;
 import uk.gov.gchq.koryphe.impl.predicate.IsIn;
 import uk.gov.gchq.koryphe.impl.predicate.IsLessThan;
 import uk.gov.gchq.koryphe.impl.predicate.IsMoreThan;
+import uk.gov.gchq.koryphe.impl.predicate.IsXLessThanY;
 import uk.gov.gchq.koryphe.impl.predicate.Not;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -34,7 +36,7 @@ import java.util.function.Function;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class MapFilterTest extends FunctionTest {
+public class MapFilterTest extends FunctionTest<MapFilter> {
 
     @Test
     public void shouldApplyKeyPredicate() {
@@ -134,8 +136,21 @@ public class MapFilterTest extends FunctionTest {
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return MapFilter.class;
+    protected Iterable<MapFilter> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new MapFilter()
+                        .keyPredicate(new IsA(String.class))
+                        .valuePredicate(new IsMoreThan(1))
+                        .keyValuePredicate(new AreEqual()),
+                new MapFilter<>()
+                        .keyPredicate(new Not<>(new IsA(String.class)))
+                        .valuePredicate(new IsLessThan(5))
+                        .keyValuePredicate(new AreEqual()),
+                new MapFilter<>()
+                        .keyPredicate(new Not<>(new IsA(String.class)))
+                        .valuePredicate(new IsMoreThan(1))
+                        .keyValuePredicate(new IsXLessThanY())
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/MapToTupleTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/MapToTupleTest.java
@@ -26,12 +26,11 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class MapToTupleTest extends FunctionTest {
+public class MapToTupleTest extends FunctionTest<MapToTuple> {
 
     @Test
     public void shouldConvertMapIntoMapTuple() {
@@ -50,13 +49,13 @@ public class MapToTupleTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected MapToTuple getInstance() {
         return new MapToTuple<String>();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return MapToTuple.class;
+    protected Iterable<MapToTuple> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/MultiplyByTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/MultiplyByTest.java
@@ -22,12 +22,13 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class MultiplyByTest extends FunctionTest {
+public class MultiplyByTest extends FunctionTest<MultiplyBy> {
 
     @Test
     public void shouldMultiplyBy2() {
@@ -94,8 +95,11 @@ public class MultiplyByTest extends FunctionTest {
     }
 
     @Override
-    protected Class<MultiplyBy> getFunctionClass() {
-        return MultiplyBy.class;
+    protected Iterable<MultiplyBy> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new MultiplyBy(),
+                new MultiplyBy(4)
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/MultiplyLongByTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/MultiplyLongByTest.java
@@ -21,12 +21,13 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class MultiplyLongByTest extends FunctionTest {
+public class MultiplyLongByTest extends FunctionTest<MultiplyLongBy> {
 
     @Test
     public void shouldMultiplyBy2() {
@@ -93,8 +94,11 @@ public class MultiplyLongByTest extends FunctionTest {
     }
 
     @Override
-    protected Class<MultiplyLongBy> getFunctionClass() {
-        return MultiplyLongBy.class;
+    protected Iterable<MultiplyLongBy> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new MultiplyLongBy(),
+                new MultiplyLongBy(100L)
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/MultiplyTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/MultiplyTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class MultiplyTest extends FunctionTest {
+public class MultiplyTest extends FunctionTest<Multiply> {
 
     @Test
     public void shouldMultiply2() {
@@ -91,8 +91,8 @@ public class MultiplyTest extends FunctionTest {
     }
 
     @Override
-    protected Class<Multiply> getFunctionClass() {
-        return Multiply.class;
+    protected Iterable<Multiply> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/NthItemTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/NthItemTest.java
@@ -22,23 +22,25 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class NthItemTest extends FunctionTest {
+public class NthItemTest extends FunctionTest<NthItem> {
 
     @Override
-    protected Function getInstance() {
+    protected NthItem getInstance() {
         return new NthItem();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return NthItem.class;
+    protected Iterable<NthItem> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new NthItem(5),
+                new NthItem(10)
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ParseDateTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ParseDateTest.java
@@ -23,21 +23,24 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ParseDateTest extends FunctionTest {
+public class ParseDateTest extends FunctionTest<ParseDate> {
     @Override
-    protected Function getInstance() {
-        return new ParseDate();
+    protected ParseDate getInstance() {
+        return new ParseDate().timeZone("UTC");
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ParseDate.class;
+    protected Iterable<ParseDate> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new ParseDate().timeZone("EST"),
+                new ParseDate().format("dd-mmm-yy HH:mm:ss")
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ParseTimeTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ParseTimeTest.java
@@ -19,24 +19,29 @@ import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
+import uk.gov.gchq.koryphe.util.TimeUnit;
 
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.function.Function;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ParseTimeTest extends FunctionTest {
+public class ParseTimeTest extends FunctionTest<ParseTime> {
     @Override
-    protected Function getInstance() {
-        return new ParseTime();
+    protected ParseTime getInstance() {
+        return new ParseTime().timeZone("UTC");
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ParseTime.class;
+    protected Iterable<ParseTime> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new ParseTime().format("dd-MMM-YYYY hh:mm:ss"),
+                new ParseTime().timeZone("PST"),
+                new ParseTime().timeUnit(TimeUnit.DAY)
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ReverseStringTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ReverseStringTest.java
@@ -18,13 +18,14 @@ package uk.gov.gchq.koryphe.impl.function;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ReverseStringTest extends FunctionTest {
+public class ReverseStringTest extends FunctionTest<ReverseString> {
 
     @Test
     public void shouldHandleNullInput() {
@@ -57,12 +58,27 @@ public class ReverseStringTest extends FunctionTest {
     }
 
     @Override
-    protected Class<? extends ReverseString> getFunctionClass() {
-        return ReverseString.class;
+    protected Iterable<ReverseString> getDifferentInstancesOrNull() {
+        return null;
     }
 
+    @Test
     @Override
     public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        ReverseString instance = getInstance();
+        String json = "" +
+                "{" +
+                    "\"class\": \"uk.gov.gchq.koryphe.impl.function.ReverseString\"" +
+                "}";
+
+        // When
+        String serialised = JsonSerialiser.serialise(instance);
+        ReverseString deserialised = JsonSerialiser.deserialise(json, ReverseString.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(instance, deserialised);
 
     }
 

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/SetValueTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/SetValueTest.java
@@ -22,12 +22,12 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
-import java.util.function.Function;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class SetValueTest extends FunctionTest {
+public class SetValueTest extends FunctionTest<SetValue> {
 
     private static final String SET_VALUE = "testVal";
 
@@ -44,13 +44,16 @@ public class SetValueTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected SetValue getInstance() {
         return new SetValue(SET_VALUE);
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return SetValue.class;
+    protected Iterable<SetValue> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new SetValue(1L),
+                new SetValue(new SetValue())
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/SizeTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/SizeTest.java
@@ -22,20 +22,19 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SizeTest extends FunctionTest {
+public class SizeTest extends FunctionTest<Size> {
     @Override
-    protected Function getInstance() {
+    protected Size getInstance() {
         return new Size();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return Size.class;
+    protected Iterable<Size> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringAppendTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringAppendTest.java
@@ -21,12 +21,13 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class StringAppendTest extends FunctionTest {
+public class StringAppendTest extends FunctionTest<StringAppend> {
 
     @Test
     public void shouldHandleNullInput() {
@@ -82,8 +83,8 @@ public class StringAppendTest extends FunctionTest {
     }
 
     @Override
-    protected Class<? extends StringAppend> getFunctionClass() {
-        return StringAppend.class;
+    protected Iterable<StringAppend> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new StringAppend("different"));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringJoinTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringJoinTest.java
@@ -23,6 +23,7 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -30,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class StringJoinTest extends FunctionTest {
+public class StringJoinTest extends FunctionTest<StringJoin> {
 
     @Test
     public void shouldHandleNullInput() {
@@ -115,8 +116,8 @@ public class StringJoinTest extends FunctionTest {
     }
 
     @Override
-    protected Class<? extends StringJoin> getFunctionClass() {
-        return StringJoin.class;
+    protected Iterable<StringJoin> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new StringJoin("\t"));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringPrependTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringPrependTest.java
@@ -21,12 +21,14 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class StringPrependTest extends FunctionTest {
+public class StringPrependTest extends FunctionTest<StringPrepend> {
 
     @Test
     public void shouldHandleNullInput() {
@@ -80,8 +82,8 @@ public class StringPrependTest extends FunctionTest {
     }
 
     @Override
-    protected Class<? extends StringPrepend> getFunctionClass() {
-        return StringPrepend.class;
+    protected Iterable<StringPrepend> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new StringPrepend("different"));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringRegexReplaceTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringRegexReplaceTest.java
@@ -21,12 +21,13 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class StringRegexReplaceTest extends FunctionTest {
+public class StringRegexReplaceTest extends FunctionTest<StringRegexReplace> {
 
     @Test
     public void shouldHandleNullInput() {
@@ -68,12 +69,16 @@ public class StringRegexReplaceTest extends FunctionTest {
 
     @Override
     protected StringRegexReplace getInstance() {
-        return new StringRegexReplace();
+        return new StringRegexReplace("replaceMe", "withThis");
     }
 
     @Override
-    protected Class<? extends StringRegexReplace> getFunctionClass() {
-        return StringRegexReplace.class;
+    protected Iterable<StringRegexReplace> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new StringRegexReplace("replaceMe", "withSomethingElse"),
+                new StringRegexReplace("r.*Me", "withThis"),
+                new StringRegexReplace()
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringRegexSplitTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringRegexSplitTest.java
@@ -21,6 +21,7 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,7 +29,7 @@ import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class StringRegexSplitTest extends FunctionTest {
+public class StringRegexSplitTest extends FunctionTest<StringRegexSplit> {
 
     @Test
     public void shouldHandleNullInput() {
@@ -57,12 +58,15 @@ public class StringRegexSplitTest extends FunctionTest {
 
     @Override
     protected StringRegexSplit getInstance() {
-        return new StringRegexSplit();
+        return new StringRegexSplit("test");
     }
 
     @Override
-    protected Class<? extends StringRegexSplit> getFunctionClass() {
-        return StringRegexSplit.class;
+    protected Iterable<StringRegexSplit> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new StringRegexSplit("hello"),
+                new StringRegexSplit(".*")
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringReplaceTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringReplaceTest.java
@@ -21,12 +21,13 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class StringReplaceTest extends FunctionTest {
+public class StringReplaceTest extends FunctionTest<StringReplace> {
 
     @Test
     public void shouldHandleNullInput() {
@@ -94,12 +95,15 @@ public class StringReplaceTest extends FunctionTest {
 
     @Override
     protected StringReplace getInstance() {
-        return new StringReplace();
+        return new StringReplace("searchForThis", "replaceWithThis");
     }
 
     @Override
-    protected Class<? extends StringReplace> getFunctionClass() {
-        return StringReplace.class;
+    protected Iterable<StringReplace> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new StringReplace("searchForThis", "test"),
+                new StringReplace("test", "replaceWithThis")
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringSplitTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringSplitTest.java
@@ -21,6 +21,7 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,7 +32,7 @@ import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class StringSplitTest extends FunctionTest {
+public class StringSplitTest extends FunctionTest<StringSplit> {
 
     @Test
     public void shouldHandleNullInput() {
@@ -91,8 +92,8 @@ public class StringSplitTest extends FunctionTest {
     }
 
     @Override
-    protected Class<? extends StringSplit> getFunctionClass() {
-        return StringSplit.class;
+    protected Iterable<StringSplit> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new StringSplit(" "));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringTrimTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringTrimTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class StringTrimTest extends FunctionTest {
+public class StringTrimTest extends FunctionTest<StringTrim> {
 
     @Test
     public void shouldHandleNullInput() {
@@ -59,8 +59,8 @@ public class StringTrimTest extends FunctionTest {
     }
 
     @Override
-    protected Class<? extends StringTrim> getFunctionClass() {
-        return StringTrim.class;
+    protected Iterable<StringTrim> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringTruncateTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/StringTruncateTest.java
@@ -21,12 +21,13 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class StringTruncateTest extends FunctionTest {
+public class StringTruncateTest extends FunctionTest<StringTruncate> {
 
     @Test
     public void shouldHandleNullInput() {
@@ -68,12 +69,16 @@ public class StringTruncateTest extends FunctionTest {
 
     @Override
     protected StringTruncate getInstance() {
-        return new StringTruncate();
+        return new StringTruncate(10, true);
     }
 
     @Override
-    protected Class<? extends StringTruncate> getFunctionClass() {
-        return StringTruncate.class;
+    protected Iterable<StringTruncate> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new StringTruncate(),
+                new StringTruncate(5, true),
+                new StringTruncate(10, false)
+        );
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToArrayTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToArrayTest.java
@@ -25,13 +25,12 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class ToArrayTest extends FunctionTest {
+public class ToArrayTest extends FunctionTest<ToArray> {
 
     @Test
     public void shouldConvertNullToArray() {
@@ -98,13 +97,13 @@ public class ToArrayTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected ToArray getInstance() {
         return new ToArray();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ToArray.class;
+    protected Iterable<ToArray> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToBytesTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToBytesTest.java
@@ -22,13 +22,14 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ToBytesTest extends FunctionTest {
+public class ToBytesTest extends FunctionTest<ToBytes> {
 
     @Test
     public void shouldGetBytes() {
@@ -55,13 +56,13 @@ public class ToBytesTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected ToBytes getInstance() {
         return new ToBytes();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ToBytes.class;
+    protected Iterable<ToBytes> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new ToBytes(StandardCharsets.US_ASCII));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToDateStringTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToDateStringTest.java
@@ -1,0 +1,110 @@
+package uk.gov.gchq.koryphe.impl.function;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ToDateStringTest extends FunctionTest<ToDateString> {
+
+    private static TimeZone originalTimezone;
+
+    @BeforeAll
+    public static void beforeClass() {
+        originalTimezone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC")); // For consistency
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        TimeZone.setDefault(originalTimezone);
+    }
+
+    @Override
+    protected Class[] getExpectedSignatureInputClasses() {
+        return new Class[] { Date.class };
+    }
+
+    @Override
+    protected Class[] getExpectedSignatureOutputClasses() {
+        return new Class[] { String.class };
+    }
+
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        Function instance = getInstance();
+        String json = "{\n" +
+                "\t\"class\": \"uk.gov.gchq.koryphe.impl.function.ToDateString\",\n" +
+                "\t\"format\": \"YYYY-MM-dd HH:mm:ss.SSS\"\n" +
+                "}";
+
+        // When
+        String serialised = JsonSerialiser.serialise(instance);
+        ToDateString deserialised = JsonSerialiser.deserialise(json, ToDateString.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(instance, deserialised);
+    }
+
+    @Override
+    protected ToDateString getInstance() {
+        return new ToDateString("YYYY-MM-dd HH:mm:ss.SSS");
+    }
+
+    @Override
+    protected Iterable<ToDateString> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new ToDateString(),
+                new ToDateString("dd-MMM-yy hh:mm:ss")
+        );
+    }
+
+    @Test
+    public void shouldConvertDateToStringAccordingToFormat() {
+        // Given
+        ToDateString instance = getInstance();
+
+        // When
+        String dateString = instance.apply(Date.from(Instant.EPOCH));
+
+        // Then
+        assertEquals("1970-01-01 00:00:00.000", dateString);
+    }
+
+    @Test
+    public void shouldUseDefaultFormatIfNoneAreGiven() {
+        // Given
+        ToDateString instance = new ToDateString();
+
+        // When
+        String dateString = instance.apply(Date.from(Instant.EPOCH));
+
+        // Then
+        assertEquals("1970-01-01T00:00:00Z", dateString);
+    }
+
+    @Test
+    public void shouldReturnNullIfInputIsNull() {
+        // Given
+        ToDateString instance = new ToDateString();
+
+        // When
+        String dateString = instance.apply(null);
+
+        // Then
+        assertNull(dateString);
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToIntegerTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToIntegerTest.java
@@ -22,12 +22,11 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class ToIntegerTest extends FunctionTest {
+public class ToIntegerTest extends FunctionTest<ToInteger> {
 
     @Test
     public void shouldConvertToInteger() {
@@ -43,13 +42,13 @@ public class ToIntegerTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected ToInteger getInstance() {
         return new ToInteger();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ToInteger.class;
+    protected Iterable<ToInteger> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToListTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToListTest.java
@@ -27,13 +27,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class ToListTest extends FunctionTest {
+public class ToListTest extends FunctionTest<ToList> {
 
     @Test
     public void shouldConvertNullToList() {
@@ -100,13 +99,13 @@ public class ToListTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected ToList getInstance() {
         return new ToList();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ToList.class;
+    protected Iterable<ToList> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToLongTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToLongTest.java
@@ -22,13 +22,12 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ToLongTest extends FunctionTest {
+public class ToLongTest extends FunctionTest<ToLong> {
 
     @Test
     public void shouldConvertToLong() {
@@ -56,13 +55,13 @@ public class ToLongTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected ToLong getInstance() {
         return new ToLong();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ToLong.class;
+    protected Iterable<ToLong> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToLowerCaseTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToLowerCaseTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ToLowerCaseTest extends FunctionTest {
+public class ToLowerCaseTest extends FunctionTest<ToLowerCase> {
 
     private static final String TEST_STRING = "TEST STRING";
 
@@ -71,13 +71,13 @@ public class ToLowerCaseTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected ToLowerCase getInstance() {
         return new ToLowerCase();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ToLowerCase.class;
+    protected Iterable<ToLowerCase> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToNullTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToNullTest.java
@@ -20,12 +20,11 @@ import uk.gov.gchq.koryphe.function.FunctionTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ToNullTest extends FunctionTest {
+public class ToNullTest extends FunctionTest<ToNull> {
 
     @Test
     public void shouldReturnNullWhenValueIsNotNull() {
@@ -52,13 +51,13 @@ public class ToNullTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected ToNull getInstance() {
         return new ToNull();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ToNull.class;
+    protected Iterable<ToNull> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToSetTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToSetTest.java
@@ -26,13 +26,12 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class ToSetTest extends FunctionTest {
+public class ToSetTest extends FunctionTest<ToSet> {
 
     @Test
     public void shouldConvertNullToSet() {
@@ -99,13 +98,13 @@ public class ToSetTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected ToSet getInstance() {
         return new ToSet();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ToSet.class;
+    protected Iterable<ToSet> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToStringTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToStringTest.java
@@ -15,6 +15,7 @@
  */
 package uk.gov.gchq.koryphe.impl.function;
 
+import org.apache.commons.io.Charsets;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.koryphe.function.FunctionTest;
@@ -22,13 +23,13 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.function.Function;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ToStringTest extends FunctionTest {
+public class ToStringTest extends FunctionTest<ToString> {
 
     @Test
     public void shouldReturnString() {
@@ -94,13 +95,13 @@ public class ToStringTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected ToString getInstance() {
         return new ToString();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ToString.class;
+    protected Iterable<ToString> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new ToString(Charsets.ISO_8859_1));
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToTupleTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToTupleTest.java
@@ -31,12 +31,11 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class ToTupleTest extends FunctionTest {
+public class ToTupleTest extends FunctionTest<ToTuple> {
 
     @Test
     public void shouldConvertListIntoArrayTuple() {
@@ -104,13 +103,13 @@ public class ToTupleTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected ToTuple getInstance() {
         return new ToTuple();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ToTuple.class;
+    protected Iterable<ToTuple> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToUpperCaseTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToUpperCaseTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ToUpperCaseTest extends FunctionTest {
+public class ToUpperCaseTest extends FunctionTest<ToUpperCase> {
 
     private static final String TEST_STRING = "test string";
 
@@ -71,13 +71,13 @@ public class ToUpperCaseTest extends FunctionTest {
     }
 
     @Override
-    protected Function getInstance() {
+    protected ToUpperCase getInstance() {
         return new ToUpperCase();
     }
 
     @Override
-    protected Class<? extends Function> getFunctionClass() {
-        return ToUpperCase.class;
+    protected Iterable<ToUpperCase> getDifferentInstancesOrNull() {
+        return null;
     }
 
     @Override

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/AgeOffFromDaysTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/AgeOffFromDaysTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AgeOffFromDaysTest extends PredicateTest {
+public class AgeOffFromDaysTest extends PredicateTest<AgeOffFromDays> {
 
     public static final int MINUTE_IN_MILLISECONDS = 60000;
     public static final int DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
@@ -103,12 +103,12 @@ public class AgeOffFromDaysTest extends PredicateTest {
     }
 
     @Override
-    protected Class<AgeOffFromDays> getPredicateClass() {
-        return AgeOffFromDays.class;
+    protected AgeOffFromDays getInstance() {
+        return new AgeOffFromDays();
     }
 
     @Override
-    protected AgeOffFromDays getInstance() {
-        return new AgeOffFromDays();
+    protected Iterable<AgeOffFromDays> getDifferentInstancesOrNull() {
+        return null;
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/AgeOffTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/AgeOffTest.java
@@ -22,13 +22,14 @@ import uk.gov.gchq.koryphe.predicate.PredicateTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AgeOffTest extends PredicateTest {
+public class AgeOffTest extends PredicateTest<AgeOff> {
 
     public static final int MINUTE_IN_MILLISECONDS = 60000;
     public static final long CUSTOM_AGE_OFF = 100000;
@@ -120,12 +121,12 @@ public class AgeOffTest extends PredicateTest {
     }
 
     @Override
-    protected Class<AgeOff> getPredicateClass() {
-        return AgeOff.class;
+    protected AgeOff getInstance() {
+        return new AgeOff();
     }
 
     @Override
-    protected AgeOff getInstance() {
-        return new AgeOff();
+    protected Iterable<AgeOff> getDifferentInstancesOrNull() {
+        return Collections.singletonList(new AgeOff(100L));
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/AndTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/AndTest.java
@@ -24,6 +24,7 @@ import uk.gov.gchq.koryphe.tuple.predicate.IntegerTupleAdaptedPredicate;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -34,7 +35,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-public class AndTest extends PredicateTest {
+public class AndTest extends PredicateTest<And> {
 
     @Test
     public void shouldAcceptWhenAllFunctionsAccept() {
@@ -240,12 +241,15 @@ public class AndTest extends PredicateTest {
     }
 
     @Override
-    protected Class<And> getPredicateClass() {
-        return And.class;
+    protected And getInstance() {
+        return new And();
     }
 
     @Override
-    protected And getInstance() {
-        return new And();
+    protected Iterable<And> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new And(new Exists(), new IsMoreThan(10L)),
+                new And(new Exists())
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/AreEqualTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/AreEqualTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AreEqualTest extends PredicateTest {
+public class AreEqualTest extends PredicateTest<AreEqual> {
 
     @Test
     public void shouldAcceptTheWhenEqualValues() {
@@ -98,12 +98,12 @@ public class AreEqualTest extends PredicateTest {
     }
 
     @Override
-    protected Class<AreEqual> getPredicateClass() {
-        return AreEqual.class;
+    protected AreEqual getInstance() {
+        return new AreEqual();
     }
 
     @Override
-    protected AreEqual getInstance() {
-        return new AreEqual();
+    protected Iterable<AreEqual> getDifferentInstancesOrNull() {
+        return null;
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/AreInTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/AreInTest.java
@@ -25,6 +25,7 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -36,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AreInTest extends PredicateTest {
+public class AreInTest extends PredicateTest<AreIn> {
 
     private static final CustomObj VALUE1 = new CustomObj();
     private static final String VALUE2 = "value2";
@@ -171,12 +172,16 @@ public class AreInTest extends PredicateTest {
     }
 
     @Override
-    protected Class<AreIn> getPredicateClass() {
-        return AreIn.class;
+    protected AreIn getInstance() {
+        return new AreIn(VALUE1);
     }
 
     @Override
-    protected AreIn getInstance() {
-        return new AreIn(VALUE1);
+    protected Iterable<AreIn> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new AreIn(),
+                new AreIn(VALUE1, VALUE2),
+                new AreIn(VALUE2)
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/CollectionContainsTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/CollectionContainsTest.java
@@ -25,6 +25,7 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -34,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CollectionContainsTest extends PredicateTest {
+public class CollectionContainsTest extends PredicateTest<CollectionContains> {
 
     private static final CustomObj VALUE1 = new CustomObj();
     private static final String VALUE2 = "value2";
@@ -143,12 +144,15 @@ public class CollectionContainsTest extends PredicateTest {
     }
 
     @Override
-    protected Class<CollectionContains> getPredicateClass() {
-        return CollectionContains.class;
+    protected CollectionContains getInstance() {
+        return new CollectionContains(VALUE1);
     }
 
     @Override
-    protected CollectionContains getInstance() {
-        return new CollectionContains(VALUE1);
+    protected Iterable<CollectionContains> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new CollectionContains(),
+                new CollectionContains(VALUE2)
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/ExistsTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/ExistsTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ExistsTest extends PredicateTest {
+public class ExistsTest extends PredicateTest<Exists> {
 
     @Test
     public void shouldAcceptTheValueWhenNotNull() {
@@ -74,12 +74,12 @@ public class ExistsTest extends PredicateTest {
     }
 
     @Override
-    protected Class<Exists> getPredicateClass() {
-        return Exists.class;
+    protected Exists getInstance() {
+        return new Exists();
     }
 
     @Override
-    protected Exists getInstance() {
-        return new Exists();
+    protected Iterable<Exists> getDifferentInstancesOrNull() {
+        return null;
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IfTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IfTest.java
@@ -25,6 +25,7 @@ import uk.gov.gchq.koryphe.tuple.predicate.KoryphePredicate2;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,20 +37,25 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-public class IfTest extends PredicateTest {
+public class IfTest extends PredicateTest<If> {
 
     @Override
     protected If<Object> getInstance() {
         return new If<>(true, new IsA(String.class), new IsA(Integer.class));
     }
 
-    private If<Comparable> getAltInstance() {
-        return new If<>(new IsA(Integer.class), new IsLessThan(3), new IsA(String.class));
+    @Override
+    protected Iterable<If> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new If<>(false, new IsA(String.class), new IsA(Integer.class)),
+                new If<>(true, new IsMoreThan(5L), new IsA(Integer.class)),
+                new If<>(true, new IsA(String.class), new IsA(Long.class)),
+                new If<>()
+        );
     }
 
-    @Override
-    protected Class<? extends Predicate> getPredicateClass() {
-        return If.class;
+    private If<Comparable> getAltInstance() {
+        return new If<>(new IsA(Integer.class), new IsLessThan(3), new IsA(String.class));
     }
 
     @Test

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsATest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsATest.java
@@ -18,9 +18,12 @@ package uk.gov.gchq.koryphe.impl.predicate;
 
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.koryphe.predicate.PredicateTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -28,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IsATest {
+public class IsATest extends PredicateTest<IsA> {
 
     @Test
     public void shouldAcceptTheValueWhenSameClass() {
@@ -118,5 +121,18 @@ public class IsATest {
         // Then 2
         assertNotNull(deserialisedFilter);
         assertEquals(type.getName(), deserialisedFilter.getType());
+    }
+
+    @Override
+    protected IsA getInstance() {
+        return new IsA(String.class);
+    }
+
+    @Override
+    protected Iterable<IsA> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new IsA(),
+                new IsA(Long.class)
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsEqualTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsEqualTest.java
@@ -23,13 +23,14 @@ import uk.gov.gchq.koryphe.util.CustomObj;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IsEqualTest extends PredicateTest {
+public class IsEqualTest extends PredicateTest<IsEqual> {
 
     @Test
     public void shouldAcceptTheTestValue() {
@@ -91,12 +92,15 @@ public class IsEqualTest extends PredicateTest {
     }
 
     @Override
-    protected Class<IsEqual> getPredicateClass() {
-        return IsEqual.class;
+    protected IsEqual getInstance() {
+        return new IsEqual("someString");
     }
 
     @Override
-    protected IsEqual getInstance() {
-        return new IsEqual("someString");
+    protected Iterable<IsEqual> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new IsEqual(),
+                new IsEqual(4L)
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsFalseTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsFalseTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IsFalseTest extends PredicateTest {
+public class IsFalseTest extends PredicateTest<IsFalse> {
 
     @Test
     public void shouldAcceptTheValueWhenFalse() {
@@ -98,12 +98,12 @@ public class IsFalseTest extends PredicateTest {
     }
 
     @Override
-    protected Class<IsFalse> getPredicateClass() {
-        return IsFalse.class;
+    protected IsFalse getInstance() {
+        return new IsFalse();
     }
 
     @Override
-    protected IsFalse getInstance() {
-        return new IsFalse();
+    protected Iterable<IsFalse> getDifferentInstancesOrNull() {
+        return null;
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsInTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsInTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IsInTest extends PredicateTest {
+public class IsInTest extends PredicateTest<IsIn> {
 
     @Test
     public void shouldAcceptWhenValueInList() {
@@ -82,12 +82,12 @@ public class IsInTest extends PredicateTest {
     }
 
     @Override
-    protected Class<IsIn> getPredicateClass() {
-        return IsIn.class;
+    protected IsIn getInstance() {
+        return new IsIn(Collections.singletonList("someValue"));
     }
 
     @Override
-    protected IsIn getInstance() {
-        return new IsIn(Collections.singletonList("someValue"));
+    protected Iterable<IsIn> getDifferentInstancesOrNull() {
+        return null;
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsLessThanTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsLessThanTest.java
@@ -24,13 +24,14 @@ import uk.gov.gchq.koryphe.util.CustomObj;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IsLessThanTest extends PredicateTest {
+public class IsLessThanTest extends PredicateTest<IsLessThan> {
 
     @Test
     public void shouldAcceptWhenLessThan() {
@@ -181,12 +182,16 @@ public class IsLessThanTest extends PredicateTest {
     }
 
     @Override
-    protected Class<IsLessThan> getPredicateClass() {
-        return IsLessThan.class;
+    protected IsLessThan getInstance() {
+        return new IsLessThan(5);
     }
 
     @Override
-    protected IsLessThan getInstance() {
-        return new IsLessThan(5);
+    protected Iterable<IsLessThan> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new IsLessThan(),
+                new IsLessThan(10),
+                new IsLessThan(5, true)
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsLongerThanTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsLongerThanTest.java
@@ -22,6 +22,7 @@ import uk.gov.gchq.koryphe.predicate.PredicateTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IsLongerThanTest extends PredicateTest {
+public class IsLongerThanTest extends PredicateTest<IsLongerThan> {
 
     @Test
     public void shouldSetAndGetMinLength() {
@@ -188,12 +189,15 @@ public class IsLongerThanTest extends PredicateTest {
     }
 
     @Override
-    protected Class<IsLongerThan> getPredicateClass() {
-        return IsLongerThan.class;
+    protected IsLongerThan getInstance() {
+        return new IsLongerThan(5);
     }
 
     @Override
-    protected IsLongerThan getInstance() {
-        return new IsLongerThan(5);
+    protected Iterable<IsLongerThan> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new IsLongerThan(),
+                new IsLongerThan(10)
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsMoreThanTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsMoreThanTest.java
@@ -23,13 +23,14 @@ import uk.gov.gchq.koryphe.util.CustomObj;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IsMoreThanTest extends PredicateTest {
+public class IsMoreThanTest extends PredicateTest<IsMoreThan> {
 
     @Test
     public void shouldAcceptTheValueWhenMoreThan() {
@@ -140,12 +141,15 @@ public class IsMoreThanTest extends PredicateTest {
     }
 
     @Override
-    protected Class<IsMoreThan> getPredicateClass() {
-        return IsMoreThan.class;
+    protected IsMoreThan getInstance() {
+        return new IsMoreThan(5);
     }
 
     @Override
-    protected IsMoreThan getInstance() {
-        return new IsMoreThan(5);
+    protected Iterable<IsMoreThan> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new IsMoreThan(),
+                new IsMoreThan(10L)
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsShorterThanTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsShorterThanTest.java
@@ -22,6 +22,7 @@ import uk.gov.gchq.koryphe.predicate.PredicateTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IsShorterThanTest extends PredicateTest {
+public class IsShorterThanTest extends PredicateTest<IsShorterThan> {
 
     @Test
     public void shouldSetAndGetMaxLength() {
@@ -188,12 +189,15 @@ public class IsShorterThanTest extends PredicateTest {
     }
 
     @Override
-    protected Class<IsShorterThan> getPredicateClass() {
-        return IsShorterThan.class;
+    protected IsShorterThan getInstance() {
+        return new IsShorterThan(5);
     }
 
     @Override
-    protected IsShorterThan getInstance() {
-        return new IsShorterThan(5);
+    protected Iterable<IsShorterThan> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new IsShorterThan(10),
+                new IsShorterThan()
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsTrueTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsTrueTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IsTrueTest extends PredicateTest {
+public class IsTrueTest extends PredicateTest<IsTrue> {
 
     @Test
     public void shouldAcceptTheValueWhenTrue() {
@@ -98,12 +98,12 @@ public class IsTrueTest extends PredicateTest {
     }
 
     @Override
-    protected Class<IsTrue> getPredicateClass() {
-        return IsTrue.class;
+    protected IsTrue getInstance() {
+        return new IsTrue();
     }
 
     @Override
-    protected IsTrue getInstance() {
-        return new IsTrue();
+    protected Iterable<IsTrue> getDifferentInstancesOrNull() {
+        return null;
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsXLessThanYTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsXLessThanYTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IsXLessThanYTest extends PredicateTest {
+public class IsXLessThanYTest extends PredicateTest<IsXLessThanY> {
 
     @Test
     public void shouldAcceptWhenLessThan() {
@@ -83,12 +83,12 @@ public class IsXLessThanYTest extends PredicateTest {
     }
 
     @Override
-    protected Class<IsXLessThanY> getPredicateClass() {
-        return IsXLessThanY.class;
+    protected IsXLessThanY getInstance() {
+        return new IsXLessThanY();
     }
 
     @Override
-    protected IsXLessThanY getInstance() {
-        return new IsXLessThanY();
+    protected Iterable<IsXLessThanY> getDifferentInstancesOrNull() {
+        return null;
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsXMoreThanYTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsXMoreThanYTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class IsXMoreThanYTest extends PredicateTest {
+public class IsXMoreThanYTest extends PredicateTest<IsXMoreThanY> {
 
     @Test
     public void shouldAcceptWhenMoreThan() {
@@ -83,12 +83,12 @@ public class IsXMoreThanYTest extends PredicateTest {
     }
 
     @Override
-    protected Class<IsXMoreThanY> getPredicateClass() {
-        return IsXMoreThanY.class;
+    protected IsXMoreThanY getInstance() {
+        return new IsXMoreThanY();
     }
 
     @Override
-    protected IsXMoreThanY getInstance() {
-        return new IsXMoreThanY();
+    protected Iterable<IsXMoreThanY> getDifferentInstancesOrNull() {
+        return null;
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/MapContainsPredicateTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/MapContainsPredicateTest.java
@@ -23,6 +23,7 @@ import uk.gov.gchq.koryphe.predicate.PredicateTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MapContainsPredicateTest extends PredicateTest {
+public class MapContainsPredicateTest extends PredicateTest<MapContainsPredicate> {
 
     private static final IsEqual KEY_PREDICATE_1 = new IsEqual("key1");
     private static final Regex KEY_PREDICATE_2 = new Regex("key.*");
@@ -118,12 +119,16 @@ public class MapContainsPredicateTest extends PredicateTest {
     }
 
     @Override
-    protected Class<MapContainsPredicate> getPredicateClass() {
-        return MapContainsPredicate.class;
+    protected MapContainsPredicate getInstance() {
+        return new MapContainsPredicate(KEY_PREDICATE_1);
     }
 
     @Override
-    protected MapContainsPredicate getInstance() {
-        return new MapContainsPredicate(KEY_PREDICATE_1);
+    protected Iterable<MapContainsPredicate> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new MapContainsPredicate(),
+                new MapContainsPredicate(new IsEqual("differentValue")),
+                new MapContainsPredicate(KEY_PREDICATE_2)
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/MapContainsTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/MapContainsTest.java
@@ -23,6 +23,7 @@ import uk.gov.gchq.koryphe.predicate.PredicateTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MapContainsTest extends PredicateTest {
+public class MapContainsTest extends PredicateTest<MapContains> {
 
     private static final String KEY1 = "key1";
     private static final String KEY2 = "key2";
@@ -102,12 +103,15 @@ public class MapContainsTest extends PredicateTest {
     }
 
     @Override
-    protected Class<MapContains> getPredicateClass() {
-        return MapContains.class;
+    protected MapContains getInstance() {
+        return new MapContains(KEY1);
     }
 
     @Override
-    protected MapContains getInstance() {
-        return new MapContains(KEY1);
+    protected Iterable<MapContains> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new MapContains(),
+                new MapContains(KEY2)
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/MultiRegexTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/MultiRegexTest.java
@@ -22,6 +22,7 @@ import uk.gov.gchq.koryphe.predicate.PredicateTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MultiRegexTest extends PredicateTest {
+public class MultiRegexTest extends PredicateTest<MultiRegex> {
 
     @Test
-    public void shouldAccepValidValue() {
+    public void shouldAcceptValidValue() {
         // Given
         Pattern[] patterns = new Pattern[2];
         patterns[0] = Pattern.compile("fail");
@@ -100,7 +101,12 @@ public class MultiRegexTest extends PredicateTest {
     }
 
     @Override
-    protected Class<MultiRegex> getPredicateClass() {
-        return MultiRegex.class;
+    protected Iterable<MultiRegex> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new MultiRegex(),
+                new MultiRegex(Pattern.compile("Something")),
+                new MultiRegex(Pattern.compile("different"), Pattern.compile("[t,T].*[t,T]"))
+        );
     }
-}
+
+    }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/NotTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/NotTest.java
@@ -23,6 +23,7 @@ import uk.gov.gchq.koryphe.signature.Signature;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,7 +34,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class NotTest extends PredicateTest {
+public class NotTest extends PredicateTest<Not> {
 
     @Test
     public void shouldAcceptTheValueWhenTheWrappedFunctionReturnsFalse() {
@@ -104,13 +105,17 @@ public class NotTest extends PredicateTest {
     }
 
     @Override
-    protected Class<Not> getPredicateClass() {
-        return Not.class;
+    protected Not<Object> getInstance() {
+        return new Not<>(new IsA(String.class));
     }
 
     @Override
-    protected Not<Object> getInstance() {
-        return new Not<>(new IsA(String.class));
+    protected Iterable<Not> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new Not<>(),
+                new Not<>(new IsEqual("test")),
+                new Not<>(new IsA(Long.class))
+        );
     }
 
     @Test

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/OrTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/OrTest.java
@@ -24,6 +24,7 @@ import uk.gov.gchq.koryphe.tuple.predicate.IntegerTupleAdaptedPredicate;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -34,7 +35,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-public class OrTest extends PredicateTest {
+public class OrTest extends PredicateTest<Or> {
 
     @Test
     public void shouldAcceptWhenOneFunctionsAccepts() {
@@ -240,12 +241,15 @@ public class OrTest extends PredicateTest {
     }
 
     @Override
-    protected Class<Or> getPredicateClass() {
-        return Or.class;
+    protected Or getInstance() {
+        return new Or(new IsA(String.class), new IsMoreThan(5L));
     }
 
     @Override
-    protected Or getInstance() {
-        return new Or();
+    protected Iterable<Or> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new Or<>(),
+                new Or<>(new IsMoreThan(5), new IsLessThan(5, true))
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/RegexTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/RegexTest.java
@@ -22,13 +22,14 @@ import uk.gov.gchq.koryphe.predicate.PredicateTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class RegexTest extends PredicateTest {
+public class RegexTest extends PredicateTest<Regex> {
 
     @Test
     public void shouldAccepValidValue() {
@@ -84,8 +85,11 @@ public class RegexTest extends PredicateTest {
     }
 
     @Override
-    protected Class<Regex> getPredicateClass() {
-        return Regex.class;
+    protected Iterable<Regex> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new Regex(),
+                new Regex("different")
+        );
     }
 
-}
+    }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/StringContainsTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/StringContainsTest.java
@@ -21,6 +21,7 @@ import uk.gov.gchq.koryphe.predicate.PredicateTest;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class StringContainsTest extends PredicateTest {
+public class StringContainsTest extends PredicateTest<StringContains> {
 
     private static final String INPUT = "This is a test string, used for the StringContains test";
 
@@ -130,12 +131,17 @@ public class StringContainsTest extends PredicateTest {
     }
 
     @Override
-    protected Predicate getInstance() {
+    protected StringContains getInstance() {
         return new StringContains("");
     }
 
     @Override
-    protected Class<? extends Predicate> getPredicateClass() {
-        return StringContains.class;
+    protected Iterable<StringContains> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+//                new StringContains(), Empty string and null have the same hashCode
+                new StringContains("different"),
+                new StringContains("", true)
+        );
     }
-}
+
+    }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/range/AbstractInTimeRangeDualTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/range/AbstractInTimeRangeDualTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public abstract class AbstractInTimeRangeDualTest<T extends Comparable<T>> extends PredicateTest {
+public abstract class AbstractInTimeRangeDualTest<T extends Comparable<T>> extends PredicateTest<AbstractInTimeRangeDual> {
 
     @AfterEach
     public void after() {
@@ -556,16 +556,25 @@ public abstract class AbstractInTimeRangeDualTest<T extends Comparable<T>> exten
     }
 
     @Override
-    protected Class<? extends Predicate> getPredicateClass() {
-        return getInstance().getClass();
-    }
-
-    @Override
-    protected Predicate getInstance() {
+    protected AbstractInTimeRangeDual getInstance() {
         return createBuilder()
                 .start("1000")
                 .end("1010")
                 .build();
+    }
+
+    @Override
+    protected Iterable<AbstractInTimeRangeDual> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                createBuilder()
+                        .start("100")
+                        .end("1010")
+                        .build(),
+                createBuilder()
+                        .start("1000")
+                        .end("2010")
+                        .build()
+        );
     }
 
     protected abstract AbstractInTimeRangeDual.BaseBuilder<?, ? extends AbstractInTimeRangeDual<T>, T> createBuilderWithTimeOffsets();

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/range/AbstractInTimeRangeTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/range/AbstractInTimeRangeTest.java
@@ -37,7 +37,7 @@ import static uk.gov.gchq.koryphe.util.DateUtil.DAYS_TO_MILLISECONDS;
 import static uk.gov.gchq.koryphe.util.DateUtil.HOURS_TO_MILLISECONDS;
 import static uk.gov.gchq.koryphe.util.DateUtil.MINUTES_TO_MILLISECONDS;
 
-public abstract class AbstractInTimeRangeTest<T extends Comparable<T>> extends PredicateTest {
+public abstract class AbstractInTimeRangeTest<T extends Comparable<T>> extends PredicateTest<AbstractInTimeRange> {
 
     @Test
     public void shouldAcceptValuesInRange() {
@@ -601,15 +601,25 @@ public abstract class AbstractInTimeRangeTest<T extends Comparable<T>> extends P
         assertEquals(end, deserialisedFilter.getEnd());
     }
 
-    protected Class<? extends AbstractInTimeRange> getPredicateClass() {
-        return getInstance().getClass();
-    }
-
-    protected AbstractInTimeRange<T> getInstance() {
+    protected AbstractInTimeRange getInstance() {
         return createBuilder()
                 .start("1000")
                 .end("1010")
                 .build();
+    }
+
+    @Override
+    protected Iterable<AbstractInTimeRange> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                createBuilder()
+                    .start("1000")
+                    .end("2000")
+                    .build(),
+                createBuilder()
+                        .start("10")
+                        .end("1010")
+                        .build()
+        );
     }
 
     protected T convert(final Long value) {

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/range/InRangeDualTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/range/InRangeDualTest.java
@@ -32,7 +32,7 @@ import java.util.function.Predicate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class InRangeDualTest<T extends Comparable<T>> extends PredicateTest {
+public class InRangeDualTest<T extends Comparable<T>> extends PredicateTest<InRangeDual> {
 
     @Test
     public void shouldAcceptValuesInRange() {
@@ -413,16 +413,25 @@ public class InRangeDualTest<T extends Comparable<T>> extends PredicateTest {
     }
 
     @Override
-    protected Class<? extends Predicate> getPredicateClass() {
-        return getInstance().getClass();
-    }
-
-    @Override
-    protected Predicate getInstance() {
+    protected InRangeDual getInstance() {
         return createBuilder()
                 .start(convert(1000L))
                 .end(convert(1010L))
                 .build();
+    }
+
+    @Override
+    protected Iterable<InRangeDual> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                createBuilder()
+                        .start(convert(100L))
+                        .end(convert(1010L))
+                        .build(),
+                createBuilder()
+                        .start(convert(1000L))
+                        .end(convert(2010L))
+                        .build()
+        );
     }
 
     protected T convert(final Long value) {

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/range/InRangeTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/range/InRangeTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class InRangeTest<T extends Comparable<T>> extends PredicateTest {
+public class InRangeTest<T extends Comparable<T>> extends PredicateTest<InRange> {
 
     @Test
     public void shouldAcceptValuesInRange() {
@@ -197,16 +197,25 @@ public class InRangeTest<T extends Comparable<T>> extends PredicateTest {
     }
 
     @Override
-    protected Class<? extends InRange> getPredicateClass() {
-        return getInstance().getClass();
-    }
-
-    @Override
     protected InRange<T> getInstance() {
         return createBuilder()
                 .start(convert(1000L))
                 .end(convert(1010L))
                 .build();
+    }
+
+    @Override
+    protected Iterable<InRange> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                createBuilder()
+                    .start(convert(100L))
+                    .end(convert(1010L))
+                    .build(),
+                createBuilder()
+                    .start(convert(1000L))
+                    .end(convert(2000L))
+                    .build()
+        );
     }
 
     protected T convert(final Long value) {

--- a/core/src/test/java/uk/gov/gchq/koryphe/predicate/AdaptedPredicateTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/predicate/AdaptedPredicateTest.java
@@ -17,15 +17,19 @@ package uk.gov.gchq.koryphe.predicate;
 
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.koryphe.impl.function.ToLowerCase;
 import uk.gov.gchq.koryphe.impl.function.ToString;
+import uk.gov.gchq.koryphe.impl.function.ToUpperCase;
 import uk.gov.gchq.koryphe.impl.predicate.IsEqual;
+import uk.gov.gchq.koryphe.impl.predicate.StringContains;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AdaptedPredicateTest {
+public class AdaptedPredicateTest extends PredicateTest<AdaptedPredicate>{
 
     @Test
     public void shouldJsonSerialiseAndDeserialise() throws IOException {
@@ -55,5 +59,19 @@ public class AdaptedPredicateTest {
         assertEquals(original.getPredicate().getClass(), deserialised.getPredicate().getClass());
         assertEquals(original.getInputAdapter().getClass(), deserialised.getInputAdapter().getClass());
         assertEquals(((IsEqual) original.getPredicate()).getControlValue(), ((IsEqual) deserialised.getPredicate()).getControlValue());
+    }
+
+    @Override
+    protected AdaptedPredicate getInstance() {
+        return new AdaptedPredicate(new ToUpperCase(), new StringContains("TEST"));
+    }
+
+    @Override
+    protected Iterable<AdaptedPredicate> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new AdaptedPredicate(new ToLowerCase(), new StringContains("TEST")),
+                new AdaptedPredicate(new ToUpperCase(), new StringContains("DIFFERENT")),
+                new AdaptedPredicate()
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/predicate/PredicateCompositeTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/predicate/PredicateCompositeTest.java
@@ -1,0 +1,141 @@
+package uk.gov.gchq.koryphe.predicate;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.impl.predicate.Exists;
+import uk.gov.gchq.koryphe.impl.predicate.IsA;
+import uk.gov.gchq.koryphe.impl.predicate.IsFalse;
+import uk.gov.gchq.koryphe.impl.predicate.IsLessThan;
+import uk.gov.gchq.koryphe.impl.predicate.IsMoreThan;
+import uk.gov.gchq.koryphe.tuple.n.Tuple1;
+import uk.gov.gchq.koryphe.tuple.predicate.TupleAdaptedPredicate;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class PredicateCompositeTest extends PredicateTest<PredicateComposite> {
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        PredicateComposite predicateComposite = getInstance();
+        String json =
+                "{" +
+                    "\"predicates\": [" +
+                        "{" +
+                            "\"class\": \"uk.gov.gchq.koryphe.impl.predicate.Exists\"" +
+                        "}," +
+                        "{" +
+                            "\"class\": \"uk.gov.gchq.koryphe.impl.predicate.IsA\"," +
+                            "\"type\": \"java.lang.Long\"" +
+                        "}" +
+                    "]" +
+                "}";
+
+        // When
+        String serialised = JsonSerialiser.serialise(predicateComposite);
+        PredicateComposite deserialised = JsonSerialiser.deserialise(json, PredicateComposite.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(predicateComposite, deserialised);
+
+    }
+
+    @Override
+    protected PredicateComposite getInstance() {
+        return new PredicateComposite(Arrays.asList(
+                new Exists(),
+                new IsA(Long.class)
+        ));
+    }
+
+    @Override
+    protected Iterable<PredicateComposite> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new PredicateComposite(Arrays.asList(
+                        new Exists(),
+                        new IsA(Integer.class))),
+                new PredicateComposite(),
+                new PredicateComposite(Arrays.asList(
+                        new IsA(Long.class),
+                        new IsMoreThan(5)))
+        );
+    }
+
+    @Test
+    public void shouldPassInputToTupleAdaptedPredicateIfAutomaticallyUnpacked() {
+        // Given
+        Integer unpackedInput = 5;
+        Tuple1<Integer> input = new Tuple1<>(unpackedInput);
+
+        // When
+        PredicateComposite predicateComposite = new PredicateComposite<>(
+                Arrays.asList(new TupleAdaptedPredicate<>(new IsLessThan(10), new Integer[]{0}))
+        );
+
+        boolean unpackedTest = predicateComposite.test(unpackedInput);
+        boolean test = predicateComposite.test(input);
+
+        // Then
+        assertTrue(unpackedTest);
+        assertTrue(test);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfInputClassesDontMatchInputAndPredicateIsNotTupleAdapted() {
+        // Given
+        String input = "test";
+
+        // When
+        PredicateComposite predicateComposite = new PredicateComposite(Arrays.asList(new IsA(String.class), new IsFalse()));
+
+        // Then
+        try {
+            predicateComposite.test(input);
+            fail("Expected an exception");
+        } catch (final ClassCastException e) {
+            assertNotNull(e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldFailIfOneOfThePredicatesDontPass() {
+        // Given
+        Long notAnInteger = 3L;
+
+        // When
+        PredicateComposite predicateComposite = new PredicateComposite(Arrays.asList(
+                new Exists(),
+                new IsA(Integer.class),
+                new IsLessThan(10)));
+
+        boolean result = predicateComposite.test(notAnInteger);
+
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    public void shouldPassIfAllThePredicatesPass() {
+        // Given
+        Integer input = 3;
+
+        // When
+        PredicateComposite predicateComposite = new PredicateComposite(Arrays.asList(
+                new Exists(),
+                new IsA(Integer.class),
+                new IsLessThan(10)));
+
+        boolean result = predicateComposite.test(input);
+
+        // Then
+        assertTrue(result);
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/predicate/PredicateMapTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/predicate/PredicateMapTest.java
@@ -20,9 +20,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.gchq.koryphe.impl.predicate.IsA;
+import uk.gov.gchq.koryphe.impl.predicate.IsMoreThan;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -37,7 +39,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests the MapFilter class can be used to mapFilter {@code FreqMap} frequencies.
  */
-public class PredicateMapTest extends PredicateTest {
+public class PredicateMapTest extends PredicateTest<PredicateMap> {
 
     private static final String KEY1 = "key1";
     private static final Date DATE_KEY = new Date();
@@ -148,12 +150,20 @@ public class PredicateMapTest extends PredicateTest {
     }
 
     @Override
-    protected Class<PredicateMap> getPredicateClass() {
-        return PredicateMap.class;
+    protected PredicateMap getInstance() {
+        return new PredicateMap<>(KEY1, new IsA(Map.class));
     }
 
     @Override
-    protected PredicateMap getInstance() {
-        return new PredicateMap<>(KEY1, new IsA(Map.class));
+    protected Iterable<PredicateMap> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new PredicateMap(
+                        KEY2, new IsA(Map.class)
+                ),
+                new PredicateMap(
+                        KEY1, new IsMoreThan(5)
+                ),
+                new PredicateMap()
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/predicate/PredicateTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/predicate/PredicateTest.java
@@ -18,6 +18,7 @@ package uk.gov.gchq.koryphe.predicate;
 
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.koryphe.util.EqualityTest;
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
@@ -27,16 +28,14 @@ import uk.gov.gchq.koryphe.util.VersionUtil;
 import java.io.IOException;
 import java.util.function.Predicate;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public abstract class PredicateTest {
+public abstract class PredicateTest<T extends Predicate> extends EqualityTest<T> {
 
-    protected abstract Predicate getInstance();
-
-    protected abstract Class<? extends Predicate> getPredicateClass();
+    protected Class<? extends Predicate> getPredicateClass() {
+        return getInstance().getClass();
+    }
 
     @Test
     public abstract void shouldJsonSerialiseAndDeserialise() throws IOException;
@@ -47,51 +46,6 @@ public abstract class PredicateTest {
 
     protected Predicate deserialise(String json) throws IOException {
         return JsonSerialiser.deserialise(json, getPredicateClass());
-    }
-
-    @Test
-    public void shouldEquals() {
-        // Given
-        final Predicate instance = getInstance();
-
-        // When
-        final Predicate other = getInstance();
-
-        // Then
-        assertEquals(instance, other);
-        assertEquals(instance.hashCode(), other.hashCode());
-    }
-
-    @Test
-    public void shouldEqualsWhenSameObject() {
-        // Given
-        final Predicate instance = getInstance();
-
-        // Then
-        assertEquals(instance, instance);
-        assertEquals(instance.hashCode(), instance.hashCode());
-    }
-
-    @Test
-    public void shouldNotEqualsWhenDifferentClass() {
-        // Given
-        final Predicate instance = getInstance();
-
-        // When
-        final Object other = new Object();
-
-        // Then
-        assertNotEquals(instance, other);
-        assertNotEquals(instance.hashCode(), other.hashCode());
-    }
-
-    @Test
-    public void shouldNotEqualsNull() {
-        // Given
-        final Predicate instance = getInstance();
-
-        // Then
-        assertNotEquals(instance, null);
     }
 
     @Test

--- a/core/src/test/java/uk/gov/gchq/koryphe/tuple/TupleInputAdapterTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/tuple/TupleInputAdapterTest.java
@@ -1,0 +1,108 @@
+package uk.gov.gchq.koryphe.tuple;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class TupleInputAdapterTest extends FunctionTest<TupleInputAdapter> {
+    @Override
+    protected Class[] getExpectedSignatureInputClasses() {
+        return new Class[] { Tuple.class };
+    }
+
+    @Override
+    protected Class[] getExpectedSignatureOutputClasses() {
+        return new Class[] { Object.class };
+    }
+
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        TupleInputAdapter<String, String> instance = getInstance();
+        String json = "" +
+                "{" +
+                "   \"class\": \"uk.gov.gchq.koryphe.tuple.TupleInputAdapter\"," +
+                "   \"selection\": [ \"input\" ]"+
+                "}";
+
+        // When
+        String serialised = JsonSerialiser.serialise(instance);
+        TupleInputAdapter deserialised = JsonSerialiser.deserialise(json, TupleInputAdapter.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(instance, deserialised);
+    }
+
+    @Override
+    protected TupleInputAdapter<String, String> getInstance() {
+        return new TupleInputAdapter<>(new String[] { "input" });
+    }
+
+    @Override
+    protected Iterable<TupleInputAdapter> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new TupleInputAdapter(),
+                new TupleInputAdapter(new String[] { "differentInput" }),
+                new TupleInputAdapter(new Integer[] { 1, 2, 3 })
+        );
+    }
+
+    @Test
+    public void shouldReturnObjectIfSingleSelectionIsProvided() {
+        // Given
+        MapTuple<String> objects = new MapTuple<>();
+        objects.put("one", 1);
+        objects.put("two", 2);
+
+        TupleInputAdapter<String, Object> inputAdapter = new TupleInputAdapter<>(new String[]{"one"});
+
+        // When
+        Object adapted = inputAdapter.apply(objects);
+
+        // Then
+        assertEquals(1, adapted);
+    }
+
+    @Test
+    public void shouldReturnNullIfTheObjectReferencedDoesntExist() {
+        // Given
+        MapTuple<String> objects = new MapTuple<>();
+        objects.put("one", 1);
+        objects.put("two", 2);
+
+        TupleInputAdapter<String, Object> inputAdapter = new TupleInputAdapter<>(new String[]{ "three" });
+
+        // When
+        Object adapted = inputAdapter.apply(objects);
+
+        // Then
+        assertNull(adapted);
+    }
+
+    @Test
+    public void shouldReturnAReferenceArrayTupleIfMoreThanOneSelectionIsProvided() {
+        // Given
+        MapTuple<String> objects = new MapTuple<>();
+        objects.put("one", 1);
+        objects.put("two", 2);
+        objects.put("three", 3);
+
+        TupleInputAdapter<String, Object> inputAdapter = new TupleInputAdapter<>(new String[]{ "one", "two" });
+
+        // When
+        Object adapted = inputAdapter.apply(objects);
+
+        // Then
+        ReferenceArrayTuple<String> expected = new ReferenceArrayTuple<>(objects, new String[]{"one", "two"});
+        assertEquals(expected, adapted);
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/tuple/TupleOutputAdapterTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/tuple/TupleOutputAdapterTest.java
@@ -1,0 +1,78 @@
+package uk.gov.gchq.koryphe.tuple;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.util.EqualityTest;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TupleOutputAdapterTest extends EqualityTest<TupleOutputAdapter> { // Can't extend FunctionTest as TupleOutputAdapter is a BiFunction rather than a Function.
+
+    @Test
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        TupleOutputAdapter instance = getInstance();
+        String json = "" +
+                "{" +
+                "   \"class\": \"uk.gov.gchq.koryphe.tuple.TupleOutputAdapter\"," +
+                "   \"projection\": [ \"input\" ]" +
+                "}";
+
+        // When
+        String serialised = JsonSerialiser.serialise(instance);
+        TupleOutputAdapter deserialised = JsonSerialiser.deserialise(json, TupleOutputAdapter.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(instance, deserialised);
+    }
+
+    @Override
+    protected TupleOutputAdapter getInstance() {
+        return new TupleOutputAdapter(new String[] { "input" });
+    }
+
+    @Override
+    protected Iterable<TupleOutputAdapter> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new TupleOutputAdapter(new String[] { "Different" }),
+                new TupleOutputAdapter(new Integer[] { 1, 2, 3 }),
+                new TupleOutputAdapter()
+        );
+    }
+
+    @Test
+    public void shouldAddToTuple() {
+        // Given
+        ArrayTuple state = new ArrayTuple(3);
+        state.put(0, "thing");
+        state.put(1, 50L);
+
+        // When
+        TupleOutputAdapter<Integer, Object> adapter = new TupleOutputAdapter<>(new Integer[]{2});
+        Tuple<Integer> adapted = adapter.apply(state, "test");
+
+        // Then
+        assertEquals("test", adapted.get(2));
+    }
+
+    @Test
+    public void shouldReplaceAnyExistingValueInTuple() {
+        // Given
+        ArrayTuple state = new ArrayTuple(3);
+        state.put(0, "thing");
+        state.put(1, 50L);
+        state.put(2, "Replace me");
+
+        // When
+        TupleOutputAdapter<Integer, Object> adapter = new TupleOutputAdapter<>(new Integer[]{2});
+        Tuple<Integer> adapted = adapter.apply(state, "test");
+
+        // Then
+        assertEquals("test", adapted.get(2));
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/tuple/binaryoperator/TupleAdaptedBinaryOperatorCompositeTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/tuple/binaryoperator/TupleAdaptedBinaryOperatorCompositeTest.java
@@ -1,0 +1,128 @@
+package uk.gov.gchq.koryphe.tuple.binaryoperator;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.binaryoperator.BinaryOperatorTest;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Max;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Product;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Sum;
+import uk.gov.gchq.koryphe.tuple.ArrayTuple;
+import uk.gov.gchq.koryphe.tuple.Tuple;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TupleAdaptedBinaryOperatorCompositeTest extends BinaryOperatorTest<TupleAdaptedBinaryOperatorComposite> {
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        TupleAdaptedBinaryOperatorComposite instance = getInstance();
+        String json = "" +
+                "{" +
+                    "\"operators\": [" +
+                        "{" +
+                            "\"selection\": [\"input\", \"anotherInput\"]," +
+                            "\"binaryOperator\": {" +
+                                "\"class\": \"uk.gov.gchq.koryphe.impl.binaryoperator.Sum\"" +
+                            "}" +
+                        "}" +
+                    "]" +
+                "}";
+
+        // When
+        String serialised = JsonSerialiser.serialise(instance);
+        TupleAdaptedBinaryOperatorComposite deserialised = JsonSerialiser.deserialise(json, TupleAdaptedBinaryOperatorComposite.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(instance, deserialised);
+
+    }
+
+    @Override
+    protected TupleAdaptedBinaryOperatorComposite getInstance() {
+        return new TupleAdaptedBinaryOperatorComposite.Builder()
+                .select(new String[] { "input", "anotherInput" })
+                .execute(new Sum())
+                .build();
+    }
+
+    @Override
+    protected Iterable<TupleAdaptedBinaryOperatorComposite> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new TupleAdaptedBinaryOperatorComposite.Builder()
+                        .select(new String[] { "differentInput", "anotherInput" })
+                        .execute(new Sum())
+                        .build(),
+                new TupleAdaptedBinaryOperatorComposite.Builder()
+                        .select(new String[] { "input", "anotherInput" })
+                        .execute(new Product())
+                        .build(),
+                new TupleAdaptedBinaryOperatorComposite(),
+                new TupleAdaptedBinaryOperatorComposite.Builder()
+                        .select(new String[] { "input", "anotherInput" })
+                        .execute(new Sum())
+                        .select(new String[] { "input", "differentInput"})
+                        .execute(new Max())
+                .build()
+        );
+    }
+
+    @Test
+    public void shouldErrorIfObjectsAreTheWrongType() {
+        // Given
+        ArrayTuple stateTuple = new ArrayTuple(5, 10, 15);
+        ArrayTuple inputTuple = new ArrayTuple(1, "two", 3);
+
+        // When
+        TupleAdaptedBinaryOperatorComposite<Integer> boc = new TupleAdaptedBinaryOperatorComposite.Builder<Integer>()
+                .select(new Integer[]{ 0 })
+                .execute(new Product())
+                .select(new Integer[] { 1 })
+                .execute(new Max())
+                .select(new Integer[] { 2 })
+                .execute(new Sum())
+                .build();
+
+        // Then
+        try {
+            boc.apply(stateTuple, inputTuple);
+            fail("Expected aggregation to fail");
+        } catch (ClassCastException e) {
+            assertNotNull(e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void shouldMergeTheInputTupleIntoTheStateTuple() {
+        // Given
+        ArrayTuple stateTuple = new ArrayTuple(5, 10, 15);
+        ArrayTuple inputTuple = new ArrayTuple(1, 2, 3);
+
+        // When
+        TupleAdaptedBinaryOperatorComposite<Integer> boc = new TupleAdaptedBinaryOperatorComposite.Builder<Integer>()
+                .select(new Integer[]{ 0 })
+                .execute(new Product())
+                .select(new Integer[] { 1 })
+                .execute(new Max())
+                .select(new Integer[] { 2 })
+                .execute(new Sum())
+                .build();
+
+        Tuple<Integer> agg = boc.apply(stateTuple, inputTuple);
+
+        // Then
+        assertEquals(5, agg.get(0));
+        assertEquals(10, agg.get(1));
+        assertEquals(18, agg.get(2));
+    }
+
+
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/tuple/binaryoperator/TupleAdaptedBinaryOperatorTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/tuple/binaryoperator/TupleAdaptedBinaryOperatorTest.java
@@ -14,18 +14,21 @@
  * limitations under the License.
  */
 
-package uk.gov.gchq.koryphe.tuple.function;
+package uk.gov.gchq.koryphe.tuple.binaryoperator;
 
 import org.junit.jupiter.api.Test;
 
+import uk.gov.gchq.koryphe.binaryoperator.BinaryOperatorTest;
 import uk.gov.gchq.koryphe.binaryoperator.MockBinaryOperator;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Product;
+import uk.gov.gchq.koryphe.impl.binaryoperator.Sum;
 import uk.gov.gchq.koryphe.tuple.Tuple;
 import uk.gov.gchq.koryphe.tuple.TupleInputAdapter;
 import uk.gov.gchq.koryphe.tuple.TupleOutputAdapter;
-import uk.gov.gchq.koryphe.tuple.binaryoperator.TupleAdaptedBinaryOperator;
 import uk.gov.gchq.koryphe.util.JsonSerialiser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 
@@ -36,7 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class TupleAdaptedBinaryOperatorTest {
+public class TupleAdaptedBinaryOperatorTest extends BinaryOperatorTest<TupleAdaptedBinaryOperator> {
 
     @Test
     public void testTupleAggregation() {
@@ -98,5 +101,19 @@ public class TupleAdaptedBinaryOperatorTest {
         Function<Tuple<String>, Integer> deserialisedInputMask = deserialisedBinaryOperator.getInputAdapter();
         assertNotSame(inputAdapter, deserialisedInputMask);
         assertTrue(deserialisedInputMask instanceof Function);
+    }
+
+    @Override
+    protected TupleAdaptedBinaryOperator getInstance() {
+        return new TupleAdaptedBinaryOperator(new Sum(), new String[] { "a", "b"});
+    }
+
+    @Override
+    protected Iterable<TupleAdaptedBinaryOperator> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new TupleAdaptedBinaryOperator(new Product(), new String[] { "a", "b"}),
+                new TupleAdaptedBinaryOperator(new Sum(), new String[] { "c", "d"}),
+                new TupleAdaptedBinaryOperator()
+        );
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/tuple/function/TupleAdaptedFunctionCompositeTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/tuple/function/TupleAdaptedFunctionCompositeTest.java
@@ -1,0 +1,142 @@
+package uk.gov.gchq.koryphe.tuple.function;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.impl.function.MultiplyLongBy;
+import uk.gov.gchq.koryphe.impl.function.ToLong;
+import uk.gov.gchq.koryphe.impl.function.ToString;
+import uk.gov.gchq.koryphe.tuple.MapTuple;
+import uk.gov.gchq.koryphe.tuple.Tuple;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class TupleAdaptedFunctionCompositeTest extends FunctionTest<TupleAdaptedFunctionComposite> {
+
+    @Override
+    protected Class[] getExpectedSignatureInputClasses() {
+        return new Class[] { Tuple.class };
+    }
+
+    @Override
+    protected Class[] getExpectedSignatureOutputClasses() {
+        return new Class[] { Tuple.class };
+    }
+
+    @Override
+    @Test
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        TupleAdaptedFunctionComposite<String> instance = getInstance();
+        String json = "" +
+                "{" +
+                    "\"functions\": [" +
+                        "{" +
+                            "\"selection\": [ \"input\" ]," +
+                            "\"function\": {" +
+                                "\"class\": \"uk.gov.gchq.koryphe.impl.function.ToLong\"" +
+                            "}," +
+                            "\"projection\": [ \"midway\" ]" +
+                        "}," +
+                        "{" +
+                            "\"selection\": [ \"midway\" ]," +
+                            "\"function\": {" +
+                                "\"class\": \"uk.gov.gchq.koryphe.impl.function.MultiplyLongBy\"," +
+                                "\"by\": 10" +
+                            "}," +
+                            "\"projection\": [ \"output\" ]" +
+                        "}" +
+                    "]" +
+                "}";
+        // When
+        String serialised = JsonSerialiser.serialise(instance);
+        TupleAdaptedFunctionComposite deserialised = JsonSerialiser.deserialise(json, TupleAdaptedFunctionComposite.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(instance, deserialised);
+    }
+
+    @Override
+    protected TupleAdaptedFunctionComposite<String> getInstance() {
+        return new TupleAdaptedFunctionComposite.Builder<String>()
+                .select(new String[] { "input" })
+                .execute(new ToLong())
+                .project(new String[] { "midway"})
+                .select(new String[] { "midway"})
+                .execute(new MultiplyLongBy(10))
+                .project(new String[] { "output"})
+                .build();
+    }
+
+    @Override
+    protected Iterable<TupleAdaptedFunctionComposite> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new TupleAdaptedFunctionComposite.Builder<String>()
+                        .select(new String[] { "DifferentInput" })
+                        .execute(new ToLong())
+                        .project(new String[] { "output"})
+                        .build(),
+                new TupleAdaptedFunctionComposite.Builder<String>()
+                        .select(new String[] { "input" })
+                        .execute(new ToString())
+                        .project(new String[] { "output"})
+                        .build(),
+                new TupleAdaptedFunctionComposite.Builder<String>()
+                        .select(new String[] { "input" })
+                        .execute(new ToLong())
+                        .project(new String[] { "differentOutput"})
+                        .build(),
+                new TupleAdaptedFunctionComposite.Builder<Integer>()
+                        .select(new Integer[] { 1 })
+                        .execute(new ToLong())
+                        .project(new Integer[] { 2 })
+                        .build(),
+                new TupleAdaptedFunctionComposite.Builder<String>()
+                        .build(),
+                new TupleAdaptedFunctionComposite.Builder<String>()
+                        .select(new String[] { "input" })
+                        .execute(new ToLong())
+                        .project(new String[] { "output"})
+                        .build()
+
+        );
+    }
+
+    @Test
+    public void shouldThrowExceptionIfInputIsWrongType() {
+        // Given
+        TupleAdaptedFunctionComposite<String> instance = getInstance();
+        MapTuple<String> inputTuple = new MapTuple<>();
+        inputTuple.put("input", "aString");
+
+        // When / Then
+        try {
+            instance.apply(inputTuple);
+            fail("Expected Function to fail as the input should be a number but was a String");
+        } catch (NumberFormatException e) {
+            assertNotNull(e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldSelectApplyAndProjectInOrder() {
+        // Given
+        TupleAdaptedFunctionComposite<String> instance = getInstance();
+        MapTuple<String> inputTuple = new MapTuple<>();
+        inputTuple.put("input", 3);
+
+        // When
+        Tuple<String> transformed = instance.apply(inputTuple);
+
+        // Then
+        assertEquals(30L, transformed.get("output"));
+
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/tuple/function/TupleAdaptedFunctionTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/tuple/function/TupleAdaptedFunctionTest.java
@@ -1,0 +1,99 @@
+package uk.gov.gchq.koryphe.tuple.function;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.impl.function.ParseDate;
+import uk.gov.gchq.koryphe.impl.function.ToLong;
+import uk.gov.gchq.koryphe.impl.function.ToUpperCase;
+import uk.gov.gchq.koryphe.tuple.ArrayTuple;
+import uk.gov.gchq.koryphe.tuple.MapTuple;
+import uk.gov.gchq.koryphe.tuple.Tuple;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TupleAdaptedFunctionTest extends FunctionTest<TupleAdaptedFunction> {
+
+    @Override
+    protected Class[] getExpectedSignatureInputClasses() {
+        return new Class[] { Tuple.class };
+    }
+
+    @Override
+    protected Class[] getExpectedSignatureOutputClasses() {
+        return new Class[] { Tuple.class };
+    }
+
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        TupleAdaptedFunction instance = getInstance();
+        String json = "" +
+                "{" +
+                    "\"selection\": [ \"input\" ]," +
+                    "\"function\": {" +
+                        "\"class\": \"uk.gov.gchq.koryphe.impl.function.ToUpperCase\"" +
+                    "}," +
+                    "\"projection\": [ \"output\" ]" +
+                "}";
+
+        // When
+        String serialised = JsonSerialiser.serialise(instance);
+        TupleAdaptedFunction deserialised = JsonSerialiser.deserialise(json, TupleAdaptedFunction.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(instance, deserialised);
+    }
+
+    @Override
+    protected TupleAdaptedFunction getInstance() {
+        return new TupleAdaptedFunction(new String[] {"input"}, new ToUpperCase(), new String[] { "output" });
+    }
+
+    @Override
+    protected Iterable<TupleAdaptedFunction> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new TupleAdaptedFunction(new String[] {"differentInput"}, new ToUpperCase(), new String[] { "output" }),
+                new TupleAdaptedFunction(new String[] {"input"}, new ToUpperCase(), new String[] { "DifferentOutput" }),
+                new TupleAdaptedFunction(new String[] {"input"}, new ParseDate(), new String[] { "output" }),
+                new TupleAdaptedFunction()
+        );
+    }
+
+    @Test
+    public void shouldErrorIfInputIsTheWrongType() {
+        // Given
+        TupleAdaptedFunction<String, Object, Long> function = new TupleAdaptedFunction<>(new String[]{"input"}, new ToLong(), new String[]{"output"});
+        MapTuple<String> inputs = new MapTuple<>();
+        inputs.put("input", "aString");
+
+        // When / Then
+        NumberFormatException e = assertThrows(NumberFormatException.class, () -> {
+            function.apply(inputs);
+        });
+
+        assertNotNull(e.getMessage());
+    }
+
+    @Test
+    public void shouldNotRemoveTheInputFromTheTuple() {
+        // Given
+        TupleAdaptedFunction<Integer, Object, String> instance = new TupleAdaptedFunction<>(new Integer[]{0}, new ToUpperCase(), new Integer[]{1});
+        ArrayTuple objects = new ArrayTuple("test", null);
+
+        // When
+        ArrayTuple returnedTuple = (ArrayTuple) instance.apply(objects);
+
+        // Then
+        assertEquals("test", returnedTuple.get(0));
+        assertEquals("TEST", returnedTuple.get(1));
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/tuple/predicate/IntegerTupleAdaptedPredicateTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/tuple/predicate/IntegerTupleAdaptedPredicateTest.java
@@ -1,0 +1,99 @@
+package uk.gov.gchq.koryphe.tuple.predicate;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.impl.predicate.Exists;
+import uk.gov.gchq.koryphe.impl.predicate.IsA;
+import uk.gov.gchq.koryphe.impl.predicate.Not;
+import uk.gov.gchq.koryphe.impl.predicate.StringContains;
+import uk.gov.gchq.koryphe.predicate.PredicateTest;
+import uk.gov.gchq.koryphe.tuple.MapTuple;
+import uk.gov.gchq.koryphe.tuple.n.Tuple1;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IntegerTupleAdaptedPredicateTest extends PredicateTest<IntegerTupleAdaptedPredicate> {
+
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        IntegerTupleAdaptedPredicate predicate = getInstance();
+        String json = "" +
+                "{" +
+                "   \"selection\": [ 1 ]," +
+                "   \"predicate\": {" +
+                "       \"class\": \"uk.gov.gchq.koryphe.impl.predicate.StringContains\"," +
+                "       \"value\": \"test\"," +
+                "       \"ignoreCase\": false" +
+                "   }" +
+                "}";
+
+        // When
+        String serialised = JsonSerialiser.serialise(predicate);
+        IntegerTupleAdaptedPredicate deserialised = JsonSerialiser.deserialise(json, IntegerTupleAdaptedPredicate.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(predicate, deserialised);
+    }
+
+    @Override
+    protected IntegerTupleAdaptedPredicate getInstance() {
+        return new IntegerTupleAdaptedPredicate(new StringContains("test"), 1);
+    }
+
+    @Override
+    protected Iterable<IntegerTupleAdaptedPredicate> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new IntegerTupleAdaptedPredicate(new StringContains("different"), 1),
+                new IntegerTupleAdaptedPredicate(new StringContains("test"), 2),
+                new IntegerTupleAdaptedPredicate(new StringContains("test"), 1, 2),
+                new IntegerTupleAdaptedPredicate()
+        );
+    }
+
+    @Test
+    public void shouldWorkWithMapTuplesWhenKeysAreIntegers() {
+        // Given
+        MapTuple<Integer> input = new MapTuple<>();
+        input.put(0, "test");
+
+        // When
+        IntegerTupleAdaptedPredicate predicate = new IntegerTupleAdaptedPredicate(new IsA(String.class), 0);
+
+        // Then
+        assertTrue(predicate.test(input));
+    }
+
+    @Test
+    public void shouldPassNullIfReferenceDoesNotExist() {
+        // Given
+        MapTuple<Integer> input = new MapTuple<>();
+        input.put(0, "test");
+
+        // When
+        IntegerTupleAdaptedPredicate predicate = new IntegerTupleAdaptedPredicate(new Not<>(new Exists()), 1);
+
+        // Then
+        assertTrue(predicate.test(input));
+    }
+
+    @Test
+    public void shouldEvaluateTupleReferenceAndApplyPredicate() {
+        // Given
+        Tuple1<Object> input = new Tuple1<>();
+        input.put(0, "test");
+
+        // When
+        IntegerTupleAdaptedPredicate predicate = new IntegerTupleAdaptedPredicate(new StringContains("te"), 0);
+
+        // Then
+        assertTrue(predicate.test(input));
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/tuple/predicate/TupleAdaptedPredicateCompositeTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/tuple/predicate/TupleAdaptedPredicateCompositeTest.java
@@ -1,0 +1,150 @@
+package uk.gov.gchq.koryphe.tuple.predicate;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.impl.predicate.IsA;
+import uk.gov.gchq.koryphe.impl.predicate.IsEqual;
+import uk.gov.gchq.koryphe.impl.predicate.IsLessThan;
+import uk.gov.gchq.koryphe.impl.predicate.IsMoreThan;
+import uk.gov.gchq.koryphe.predicate.PredicateTest;
+import uk.gov.gchq.koryphe.tuple.MapTuple;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TupleAdaptedPredicateCompositeTest extends PredicateTest<TupleAdaptedPredicateComposite> {
+
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        TupleAdaptedPredicateComposite instance = getInstance();
+
+        String json = "" +
+                "{" +
+                "   \"predicates\": [" +
+                "       {" +
+                "           \"selection\": [ \"test\" ]," +
+                "           \"predicate\": {" +
+                "               \"class\": \"uk.gov.gchq.koryphe.impl.predicate.IsMoreThan\"," +
+                "               \"value\": {" +
+                "                   \"java.lang.Long\": 10" +
+                "               }," +
+                "               \"orEqualTo\": false" +
+                "           }" +
+                "       }," +
+                "       {" +
+                "           \"selection\": [ \"differentTest\" ]," +
+                "           \"predicate\": {" +
+                "               \"class\": \"uk.gov.gchq.koryphe.impl.predicate.IsA\"," +
+                "               \"type\": \"java.lang.String\"" +
+                "           }" +
+                "       }" +
+                "   ]" +
+                "}";
+        // When
+        String serialised = JsonSerialiser.serialise(instance);
+        TupleAdaptedPredicateComposite deserialised = JsonSerialiser.deserialise(json, TupleAdaptedPredicateComposite.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(instance, deserialised);
+    }
+
+    @Override
+    protected TupleAdaptedPredicateComposite getInstance() {
+        return new TupleAdaptedPredicateComposite.Builder<String>()
+                .select(new String[]{ "test" })
+                .execute(new IsMoreThan(10L))
+                .select(new String[] { "differentTest"})
+                .execute(new IsA(String.class))
+                .build();
+    }
+
+    @Override
+    protected Iterable<TupleAdaptedPredicateComposite> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new TupleAdaptedPredicateComposite.Builder<String>()
+                        .select(new String[]{ "test" })
+                        .execute(new IsMoreThan(10L))
+                        .select(new String[] { "differentTest"})
+                        .execute(new IsA(Long.class))
+                        .build(),
+                new TupleAdaptedPredicateComposite.Builder<String>()
+                        .select(new String[]{ "test" })
+                        .execute(new IsMoreThan(10L))
+                        .select(new String[] { "differentTest"})
+                        .execute(new IsLessThan(5))
+                        .build(),
+                new TupleAdaptedPredicateComposite.Builder<String>()
+                    .select(new String[]{ "test" })
+                    .execute(new IsMoreThan(10L))
+                    .select(new String[] { "differentTest1"})
+                    .execute(new IsA(String.class))
+                    .build(),
+                new TupleAdaptedPredicateComposite.Builder<String>()
+                        .select(new String[]{ "test1" })
+                        .execute(new IsMoreThan(10L))
+                        .select(new String[] { "differentTest"})
+                        .execute(new IsA(Long.class))
+                        .build(),
+                new TupleAdaptedPredicateComposite.Builder<String>()
+                        .select(new String[]{ "test" })
+                        .execute(new IsMoreThan(5L))
+                        .select(new String[] { "differentTest"})
+                        .execute(new IsA(Long.class))
+                        .build(),
+                new TupleAdaptedPredicateComposite.Builder<String>()
+                        .select(new String[]{ "test" })
+                        .execute(new IsEqual(10L))
+                        .select(new String[] { "differentTest"})
+                        .execute(new IsA(Long.class))
+                        .build(),
+                new TupleAdaptedPredicateComposite()
+        );
+    }
+
+    @Test
+    public void shouldFailFast() {
+        // Given
+        TupleAdaptedPredicateComposite<String> composite = new TupleAdaptedPredicateComposite.Builder<String>()
+                .select(new String[]{"fail"})
+                .execute(new IsA(String.class))
+                .select(new String[]{"error"})
+                .execute(new IsMoreThan(10L))
+                .build();
+
+        MapTuple<String> objects = new MapTuple<>();
+        objects.put("fail", 5L); // not a string will cause IsA check to fail
+        objects.put("error", new IsLessThan()); // IsLessThan does not implement Comparable so will error.
+
+        // When
+        boolean result = composite.test(objects); // no error
+
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    public void shouldReturnTrueIfAllTestsPass() {
+        // Given
+        TupleAdaptedPredicateComposite instance = getInstance();
+        MapTuple<String> objects = new MapTuple<>();
+
+        objects.put("test", 100L);
+        objects.put("differentTest", "pass");
+        
+        // When
+        boolean test = instance.test(objects);
+
+        // Then
+        assertTrue(test);
+    }
+
+
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/tuple/predicate/TupleAdaptedPredicateTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/tuple/predicate/TupleAdaptedPredicateTest.java
@@ -1,0 +1,53 @@
+package uk.gov.gchq.koryphe.tuple.predicate;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.impl.predicate.IsA;
+import uk.gov.gchq.koryphe.impl.predicate.IsMoreThan;
+import uk.gov.gchq.koryphe.predicate.PredicateTest;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TupleAdaptedPredicateTest extends PredicateTest<TupleAdaptedPredicate> {
+
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        TupleAdaptedPredicate predicate = getInstance();
+        String json = "" +
+                "{" +
+                "   \"selection\": [ \"input\" ]," +
+                "   \"predicate\": {" +
+                "       \"class\": \"uk.gov.gchq.koryphe.impl.predicate.IsA\"," +
+                "       \"type\": \"java.lang.String\"" +
+                "   }" +
+                "}";
+
+        // When
+        String serialised = JsonSerialiser.serialise(predicate);
+        TupleAdaptedPredicate deserialised = JsonSerialiser.deserialise(json, TupleAdaptedPredicate.class);
+
+        // Then
+        JsonSerialiser.assertEquals(json, serialised);
+        assertEquals(predicate, deserialised);
+    }
+
+    @Override
+    protected TupleAdaptedPredicate getInstance() {
+        return new TupleAdaptedPredicate(new IsA(String.class), new String[] { "input" });
+    }
+
+    @Override
+    protected Iterable<TupleAdaptedPredicate> getDifferentInstancesOrNull() {
+        return Arrays.asList(
+                new TupleAdaptedPredicate(new IsA(Long.class), new String[] { "input" }),
+                new TupleAdaptedPredicate(new IsMoreThan(5), new String[] { "input" }),
+                new TupleAdaptedPredicate(new IsA(String.class), new String[] { "Different" })
+        );
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/util/EqualityTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/util/EqualityTest.java
@@ -1,0 +1,140 @@
+package uk.gov.gchq.koryphe.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * A TestClass which checks for equality and inequality using both the Equals and Hashcode methods of an object
+ * @param <T> The Class of object that is being tested.
+ */
+public abstract class EqualityTest<T> {
+
+    /**
+     * Provides a new instance to test equality against.
+     * @return an instance
+     */
+    protected abstract T getInstance();
+
+
+    /**
+     * Provides an iterable of instances which should not equal the instance provided
+     * by {@code getInstance()}. If the instance does not have any variety (ie it has
+     * no fields) then null should be returned.
+     * @return an iterable of instances which are different to that provided by
+     * {@code getInstance()}
+     */
+    protected abstract Iterable<T> getDifferentInstancesOrNull();
+
+    @Test
+    public void shouldEqualsItself() {
+        // Given
+        T instance = getInstance();
+
+        // When
+        T itself = instance; // only added this line to make the test explicit and read better
+
+        // Then
+        assertEquals(instance, itself);
+    }
+
+    @Test
+    public void shouldHaveTheSameHashcodeAsItself() {
+        // Given
+        T instance = getInstance();
+
+        // When
+        T itself = instance; // only added this line to make the test explicit and read better
+
+        // Then
+        assertEquals(instance.hashCode(), itself.hashCode());
+    }
+
+    @Test
+    public void shouldEqualsTheSameObject() {
+        // Given
+        T instance = getInstance();
+
+        // When
+        T sameObject = getInstance();
+
+        // Then
+        assertEquals(instance, sameObject);
+    }
+
+    @Test
+    public void shouldHaveTheSameHashcodeAsTheSameObject() {
+        // Given
+        T instance = getInstance();
+
+        // When
+        T sameObject = getInstance();
+
+        // Then
+        assertEquals(instance.hashCode(), sameObject.hashCode());
+    }
+
+    @Test
+    public void shouldNotEqualsNull() {
+        // Given
+        T instance = getInstance();
+
+        // When
+        T nullObject = null; // only added this line to make the test explicit and read better
+
+        // Then
+        assertNotEquals(instance, nullObject);
+    }
+
+    @Test
+    public void shouldNotEqualsDifferentClass() {
+        // Given
+        T instance = getInstance();
+
+        // When
+        DifferentClass differentObject = new DifferentClass(); // only added this line to make the test explicit and read better
+
+        // Then
+        assertNotEquals(instance, differentObject);
+    }
+
+    @Test
+    public void shouldNotEqualDifferentInstances() {
+        // Given
+        T instance = getInstance();
+        Iterable<T> alternativeInstances = getDifferentInstancesOrNull();
+
+        // When
+        if (alternativeInstances == null) {
+            return;
+        }
+
+        // Then
+        for (T alternativeInstance : alternativeInstances) {
+            assertNotEquals(instance, alternativeInstance);
+        }
+    }
+
+    @Test
+    public void shouldHaveDifferentHashcodesToDifferentInstances() {
+        // Given
+        T instance = getInstance();
+        Iterable<T> alternativeInstances = getDifferentInstancesOrNull();
+
+        // When
+        if (alternativeInstances == null) {
+            return;
+        }
+
+        // Then
+        for (T alternativeInstance : alternativeInstances) {
+            assertNotEquals(instance.hashCode(), alternativeInstance.hashCode());
+        }
+    }
+
+    private static class DifferentClass {
+        // Used for testing equality with different classes
+    }
+
+}


### PR DESCRIPTION
* gh-195 Added abstract equality checking test and refactored tests up to MapFilter

* gh-195 Finished Function Tests

* gh-195 passing checkstyle

* gh-195 Predicates done

* gh-195 Made different Instances Manditory for all tests

* gh-195 removed redundent getFunction / getPredicateClass

* gh-195 Ensured TupleAdapted predicates, functions and binary operators all implement equals/hashcode correctly

* gh-195 tidied some things up

* gh-195 Identified untested classes

* gh-195 Added further EqualityTests

* gh-195 enabled json serialisation tests and added tests to Composites and TupleAdaptedFunctions

* gh-195 Finished tests

* Fixed dodgy grammar

Co-authored-by: t11947 <53758970+t11947@users.noreply.github.com>

* gh-195 renamed method, added javadoc and changed some of the hashcode numbers

* gh-195 reverted classEquals for findbugs and used assertThrows

Co-authored-by: t11947 <53758970+t11947@users.noreply.github.com>