### PR TITLE
gh-149 Add flag to ParseDate to handle microsecond accuracy input.

### DIFF
--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ParseDate.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ParseDate.java
@@ -41,6 +41,7 @@ import static java.util.Objects.nonNull;
 public class ParseDate extends KorypheFunction<String, Date> {
     private String format;
     private TimeZone timeZone;
+    private boolean microseconds;
 
     public ParseDate() {
         setTimeZone((TimeZone) null);
@@ -55,7 +56,7 @@ public class ParseDate extends KorypheFunction<String, Date> {
         try {
             final Date date;
             if (isNull(format)) {
-                date = DateUtil.parse(dateString, timeZone);
+                date = DateUtil.parse(dateString, timeZone, microseconds);
             } else {
                 final SimpleDateFormat simpleDateFormat = new SimpleDateFormat(format);
                 if (nonNull(timeZone)) {
@@ -114,6 +115,20 @@ public class ParseDate extends KorypheFunction<String, Date> {
         return this;
     }
 
+    public boolean isMicroseconds() {
+        return microseconds;
+    }
+
+    @JsonSetter
+    public void setMicroseconds(final boolean microseconds) {
+        this.microseconds = microseconds;
+    }
+
+    public ParseDate microseconds(final boolean microseconds) {
+        setMicroseconds(microseconds);
+        return this;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -128,6 +143,7 @@ public class ParseDate extends KorypheFunction<String, Date> {
         return new EqualsBuilder()
                 .append(timeZone, that.timeZone)
                 .append(format, that.format)
+                .append(microseconds, that.microseconds)
                 .isEquals();
     }
 
@@ -137,6 +153,7 @@ public class ParseDate extends KorypheFunction<String, Date> {
                 .appendSuper(super.hashCode())
                 .append(timeZone)
                 .append(format)
+                .append(microseconds)
                 .toHashCode();
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ParseDateTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ParseDateTest.java
@@ -64,7 +64,7 @@ public class ParseDateTest extends FunctionTest<ParseDate> {
         final ParseDate deserialised = JsonSerialiser.deserialise(json, ParseDate.class);
 
         // Then
-        JsonSerialiser.assertEquals("{\"class\":\"uk.gov.gchq.koryphe.impl.function.ParseDate\",\"format\":\"yyyy dd\",\"timeZone\":\"GMT\"}", json);
+        JsonSerialiser.assertEquals("{\"class\":\"uk.gov.gchq.koryphe.impl.function.ParseDate\",\"format\":\"yyyy dd\",\"timeZone\":\"GMT\",\"microseconds\":false}", json);
         assertEquals(function.getFormat(), deserialised.getFormat());
         assertEquals(function.getTimeZone(), deserialised.getTimeZone());
     }
@@ -93,6 +93,33 @@ public class ParseDateTest extends FunctionTest<ParseDate> {
 
         // Then
         assertEquals(new SimpleDateFormat("yyyy-MM hh:mm:ss.SSS").parse(input), result);
+    }
+
+    @Test
+    public void shouldParseTimestampInMilliseconds() throws ParseException {
+        // Given
+        final ParseDate function = new ParseDate();
+        final String input = "946782245006";
+
+        // When
+        final Date result = function.apply(input);
+
+        // Then
+        assertEquals(new Date(Long.parseLong(input)), result);
+    }
+
+    @Test
+    public void shouldParseTimestampInMicroseconds() throws ParseException {
+        // Given
+        final ParseDate function = new ParseDate();
+        function.setMicroseconds(true);
+        final String input = "946782245006000";
+
+        // When
+        final Date result = function.apply(input);
+
+        // Then
+        assertEquals(new Date(Long.parseLong(input.substring(0, input.length() - 3))), result);
     }
 
     @Test


### PR DESCRIPTION
Added an implementation which enables the `ParseDate` to handle input epoch timestamps specified to microsecond accuracy. The default handling is set to expect epoch timestamps to be provided with millisecond accuracy.