### PR TITLE
gh-149: Replace usage of Math.floorMod() with % operator.

### DIFF
--- a/core/src/main/java/uk/gov/gchq/koryphe/util/DateUtil.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/util/DateUtil.java
@@ -102,7 +102,7 @@ public final class DateUtil {
                     final long epochMicroseconds = Long.parseLong(dateString);
 
                     final long epochSeconds = MICROSECONDS.toSeconds(epochMicroseconds);
-                    final long nanos = MICROSECONDS.toNanos(Math.floorMod(epochMicroseconds, TimeUnit.SECONDS.toMicros(1)));
+                    final long nanos = MICROSECONDS.toNanos(epochMicroseconds % TimeUnit.SECONDS.toMicros(1));
 
                     return Date.from(Instant.ofEpochSecond(epochSeconds, nanos));
                 }


### PR DESCRIPTION
Improve performance and readability by swapping the Math.floorMod() method for the % operator.

The only difference between the two should be when there are negative inputs, but that doesn't apply here as we'd always expect valid input to this function (i.e. the timestamp should also be positive).

# Related Issue

- Resolve #149