### PR TITLE
gh-259 added ToBoolean function and corresponding tests

### DIFF
--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToBoolean.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToBoolean.java
@@ -37,7 +37,7 @@ public class ToBoolean extends KorypheFunction<Object, Boolean> {
         }
 
         if (value instanceof String) {
-            return Boolean.parseBoolean((String)value);
+            return Boolean.parseBoolean((String) value);
         }
 
         throw new IllegalArgumentException("Could not convert value to Boolean: " + value);

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToBoolean.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToBoolean.java
@@ -16,6 +16,8 @@
 
 package uk.gov.gchq.koryphe.impl.function;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import uk.gov.gchq.koryphe.Since;
 import uk.gov.gchq.koryphe.Summary;
 import uk.gov.gchq.koryphe.function.KorypheFunction;
@@ -26,16 +28,18 @@ import uk.gov.gchq.koryphe.function.KorypheFunction;
  * <p>
  * The resulting object is what is returned from the method.
  */
+
 @Since("2.0.0")
 @Summary("Casts input Object to a Boolean")
 public class ToBoolean extends KorypheFunction<Object, Boolean> {
 
+    @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL",
+    justification = "null values should be allowed")
     @Override
     public Boolean apply(final Object value) {
         if (null == value) {
             return null;
         }
-
         if (value instanceof String) {
             return Boolean.parseBoolean((String) value);
         }

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToBoolean.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToBoolean.java
@@ -41,7 +41,10 @@ public class ToBoolean extends KorypheFunction<Object, Boolean> {
             return null;
         }
         if (value instanceof String) {
-            return Boolean.parseBoolean((String) value);
+            return Boolean.valueOf((String) value);
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value;
         }
 
         throw new IllegalArgumentException("Could not convert value to Boolean: " + value);

--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToBoolean.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/ToBoolean.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.koryphe.impl.function;
+
+import uk.gov.gchq.koryphe.Since;
+import uk.gov.gchq.koryphe.Summary;
+import uk.gov.gchq.koryphe.function.KorypheFunction;
+
+/**
+ * A <code>ToBoolean</code> is a {@link java.util.function.Function} that takes
+ * an Object and casts it to a Boolean.
+ * <p>
+ * The resulting object is what is returned from the method.
+ */
+@Since("2.0.0")
+@Summary("Casts input Object to a Boolean")
+public class ToBoolean extends KorypheFunction<Object, Boolean> {
+
+    @Override
+    public Boolean apply(final Object value) {
+        if (null == value) {
+            return null;
+        }
+
+        if (value instanceof String) {
+            return Boolean.parseBoolean((String)value);
+        }
+
+        throw new IllegalArgumentException("Could not convert value to Boolean: " + value);
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToBooleanTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToBooleanTest.java
@@ -40,7 +40,7 @@ public class ToBooleanTest extends FunctionTest<ToBoolean> {
     }
 
     @Test
-    public void shouldConvertStringToBoolean() {
+    public void shouldConvertNonBooleanStringToFalseBoolean() {
         // Given
         final ToBoolean function = new ToBoolean();
 
@@ -78,6 +78,20 @@ public class ToBooleanTest extends FunctionTest<ToBoolean> {
         // Then
         assertThat(output)
                 .isEqualTo(false)
+                .isExactlyInstanceOf(Boolean.class);
+    }
+
+    @Test
+    public void shouldReturnAGivenBoolean() {
+        // Given
+        final ToBoolean function = new ToBoolean();
+
+        // When
+        Object output = function.apply(Boolean.TRUE);
+
+        // Then
+        assertThat(output)
+                .isEqualTo(Boolean.TRUE)
                 .isExactlyInstanceOf(Boolean.class);
     }
 

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToBooleanTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToBooleanTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.gchq.koryphe.impl.function;
+
+import org.junit.jupiter.api.Test;
+
+import uk.gov.gchq.koryphe.function.FunctionTest;
+import uk.gov.gchq.koryphe.util.JsonSerialiser;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class ToBooleanTest extends FunctionTest<ToBoolean> {
+
+    @Test
+    public void shouldThrowException() {
+        // Given
+        final ToBoolean function = new ToBoolean();
+
+        // When / Then
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> function.apply(5.2))
+                .withMessageContaining("Could not convert value to Boolean: ");
+    }
+
+    @Test
+    public void shouldConvertStringTrueToBoolean() {
+        // Given
+        final ToBoolean function = new ToBoolean();
+
+        // When
+        Object output = function.apply("true");
+
+        // Then
+        assertThat(output)
+                .isEqualTo(true)
+                .isExactlyInstanceOf(Boolean.class);
+    }
+
+    @Test
+    public void shouldConvertStringFalseToBoolean() {
+        // Given
+        final ToBoolean function = new ToBoolean();
+
+        // When
+        Object output = function.apply("false");
+
+        // Then
+        assertThat(output)
+                .isEqualTo(false)
+                .isExactlyInstanceOf(Boolean.class);
+    }
+
+    @Test
+    public void shouldReturnNullWhenValueIsNull() {
+        // Given
+        final ToBoolean function = new ToBoolean();
+
+        // When
+        final Object output = function.apply(null);
+
+        // Then
+        assertThat(output).isNull();
+    }
+
+    @Override
+    protected ToBoolean getInstance() {
+        return new ToBoolean();
+    }
+
+    @Override
+    protected Iterable<ToBoolean> getDifferentInstancesOrNull() {
+        return null;
+    }
+
+    @Override
+    protected Class[] getExpectedSignatureInputClasses() {
+        return new Class[] { Object.class };
+    }
+
+    @Override
+    protected Class[] getExpectedSignatureOutputClasses() {
+        return new Class[] { Boolean.class };
+    }
+
+    @Test
+    @Override
+    public void shouldJsonSerialiseAndDeserialise() throws IOException {
+        // Given
+        final ToBoolean function = new ToBoolean();
+
+        // When
+        final String json = JsonSerialiser.serialise(function);
+
+        // Then
+        JsonSerialiser.assertEquals(String.format("{%n" +
+                "  \"class\" : \"uk.gov.gchq.koryphe.impl.function.ToBoolean\"%n" +
+                "}"), json);
+
+        // When 2
+        final ToBoolean deserialisedMethod = JsonSerialiser.deserialise(json, ToBoolean.class);
+
+        // Then 2
+        assertThat(deserialisedMethod).isNotNull();
+    }
+}

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToBooleanTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/ToBooleanTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 public class ToBooleanTest extends FunctionTest<ToBoolean> {
 
     @Test
-    public void shouldThrowException() {
+    public void shouldThrowExceptionIfIncorrectTypeGiven() {
         // Given
         final ToBoolean function = new ToBoolean();
 
@@ -37,6 +37,20 @@ public class ToBooleanTest extends FunctionTest<ToBoolean> {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> function.apply(5.2))
                 .withMessageContaining("Could not convert value to Boolean: ");
+    }
+
+    @Test
+    public void shouldConvertStringToBoolean() {
+        // Given
+        final ToBoolean function = new ToBoolean();
+
+        // When
+        Object output = function.apply("test");
+
+        // Then
+        assertThat(output)
+                .isEqualTo(false)
+                .isExactlyInstanceOf(Boolean.class);
     }
 
     @Test


### PR DESCRIPTION
This is a missing koryphe function required by gh-2558-openCypherCSV. Takes an object and converts it into a Boolean

# Related Issue

- Resolve #259