### PR TITLE
Replaced HashSet with LinkedHashSet for deterministic ordering in IsIn

### DIFF
--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/predicate/IsIn.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/predicate/IsIn.java
@@ -30,7 +30,8 @@ import uk.gov.gchq.koryphe.predicate.KoryphePredicate;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -47,11 +48,12 @@ public class IsIn extends KoryphePredicate<Object> {
     }
 
     public IsIn(final Collection<Object> controlData) {
-        this.allowedValues = new HashSet<>(controlData);
+        this.allowedValues = new LinkedHashSet<>(controlData);
     }
 
     public IsIn(final Object... controlData) {
-        this.allowedValues = Sets.newHashSet(controlData);
+        this.allowedValues = Sets.newLinkedHashSet();
+        Collections.addAll(this.allowedValues, controlData);
     }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_OBJECT)
@@ -64,9 +66,9 @@ public class IsIn extends KoryphePredicate<Object> {
     @JsonProperty("values")
     public void setAllowedValues(final Object[] allowedValuesArray) {
         if (null != allowedValuesArray) {
-            allowedValues = new HashSet<>(Arrays.asList(allowedValuesArray));
+            allowedValues = new LinkedHashSet<>(Arrays.asList(allowedValuesArray));
         } else {
-            allowedValues = new HashSet<>(0);
+            allowedValues = new LinkedHashSet<>(0);
         }
     }
 


### PR DESCRIPTION
The indeterministic ordering of a HashSet in the IsIn class causes the ordering of objects when serialized (to a JSON string) to be inconsistent sometimes. The following test case fails if this happens: 

https://github.com/gchq/koryphe/blob/36c63c3e24145e04405d7620524b23cf9b5b5849/core/src/test/java/uk/gov/gchq/koryphe/impl/predicate/IsInTest.java#L53

This change was confirmed by running the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

To reproduce this problem, you can run the test with NonDex using this command:

```
mvn -pl core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=uk.gov.gchq.koryphe.impl.predicate.IsInTest#shouldJsonSerialiseAndDeserialise
```

This PR proposes to replace the HashSet in the IsIn class with a LinkedHashSet, maintaining insertion order so that the test case is correct. It didn't make sense to me to simply change the test case, since the test case is testing serialization of the IsIn class and is comparing two JSON strings, which cannot be sorted or really manipulated.  

Please let me know if you want to discuss these changes. 