### PR TITLE
Gh-324: Make IterableConcat's type signature more flexible

### DIFF
--- a/core/src/main/java/uk/gov/gchq/koryphe/impl/function/IterableConcat.java
+++ b/core/src/main/java/uk/gov/gchq/koryphe/impl/function/IterableConcat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,9 @@ import uk.gov.gchq.koryphe.util.IterableUtil;
  */
 @Since("1.1.0")
 @Summary("Concatenates 2 iterables")
-public class IterableConcat<I_ITEM> extends KorypheFunction<Iterable<Iterable<I_ITEM>>, Iterable<I_ITEM>> {
+public class IterableConcat<I_ITEM> extends KorypheFunction<Iterable<? extends Iterable<I_ITEM>>, Iterable<I_ITEM>> {
     @Override
-    public Iterable<I_ITEM> apply(final Iterable<Iterable<I_ITEM>> items) {
+    public Iterable<I_ITEM> apply(final Iterable<? extends Iterable<I_ITEM>> items) {
         return IterableUtil.concat(items);
     }
 }

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableConcatTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableConcatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableConcatTest.java
+++ b/core/src/test/java/uk/gov/gchq/koryphe/impl/function/IterableConcatTest.java
@@ -24,6 +24,8 @@ import uk.gov.gchq.koryphe.util.JsonSerialiser;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -84,6 +86,23 @@ public class IterableConcatTest extends FunctionTest<IterableConcat> {
         assertThat(result)
                 .isNotNull()
                 .containsExactly(1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void shouldFlattenWhenIterableNestedTypeExtendsIterable() {
+        // Given
+        final IterableConcat<Integer> function = new IterableConcat<>();
+        final Iterable<Set<Integer>> input = Arrays.asList(
+                new HashSet<>(Arrays.asList(5)),
+                new HashSet<>(Arrays.asList(10)));
+
+        // When
+        final Iterable<Integer> result = function.apply(input);
+
+        // Then
+        assertThat(result)
+                .isNotNull()
+                .containsExactly(5, 10);
     }
 
     @Test

--- a/doc/src/main/java/uk/gov/gchq/koryphe/example/function/iterable/IterableConcatExample.java
+++ b/doc/src/main/java/uk/gov/gchq/koryphe/example/function/iterable/IterableConcatExample.java
@@ -26,7 +26,8 @@ import java.util.stream.Stream;
 public class IterableConcatExample extends KorypheIterableFunctionExample<Iterable<Iterable<Integer>>, Iterable<Integer>> {
     @Override
     public Function<Iterable<Iterable<Integer>>, Iterable<Integer>> getFunction() {
-        return new IterableConcat();
+        Function<? extends Iterable<? extends Iterable<Integer>>, Iterable<Integer>> f = new IterableConcat<>();
+        return ((Function<Iterable<Iterable<Integer>>, Iterable<Integer>>) f);
     }
 
     @Override

--- a/doc/src/main/java/uk/gov/gchq/koryphe/example/function/iterable/IterableConcatExample.java
+++ b/doc/src/main/java/uk/gov/gchq/koryphe/example/function/iterable/IterableConcatExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Crown Copyright
+ * Copyright 2017-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 public class IterableConcatExample extends KorypheIterableFunctionExample<Iterable<Iterable<Integer>>, Iterable<Integer>> {
     @Override
     public Function<Iterable<Iterable<Integer>>, Iterable<Integer>> getFunction() {
-        return new IterableConcat<>();
+        return new IterableConcat();
     }
 
     @Override


### PR DESCRIPTION
IterableConcat can now easily accept nested Iterables which extend Iterable in more cases

# Related issue

- Resolve #324